### PR TITLE
Generate video preview image

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,6 +119,9 @@ gem "os"
 # Shrine is a better alternative to ActiveStorage for handling file attachments and the like
 gem "shrine", "~> 3.0"
 
+# Stremio-ffmpeg use the ffmpeg library to process our video files
+gem "streamio-ffmpeg"
+
 # Scraper gems
 # Local testing
 gem "zorki", "0.1.0", path: "~/Repositories/zorki" # instagram

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
     mini_portile2 (2.5.3)
     minitest (5.14.4)
     msgpack (1.4.2)
+    multi_json (1.15.0)
     nio4r (2.5.7)
     nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
@@ -314,6 +315,8 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (0.2.4)
       rails (>= 6.0.0)
+    streamio-ffmpeg (3.0.2)
+      multi_json (~> 1.8)
     tailwindcss-rails (0.3.3)
       rails (>= 6.0.0)
     thor (1.1.0)
@@ -398,6 +401,7 @@ DEPENDENCIES
   sorbet-runtime
   sorted_set
   spring
+  streamio-ffmpeg
   tailwindcss-rails (~> 0.3.3)
   tmuxinator
   turbolinks (~> 5)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ If `pg_config` isn't already in your `PATH`, locate it (try looking in `/Library
 ### Yarn
 An open-source Javascript package manager used to install/manage Webpack and some other package dependencies
 
+### FFMPEG
+
+FFMPEG is a video processing library. It's used on that Mars helicopter and at YouTube, so it's fine.
+We need to install it to process previews for videos.
+
+MacOS: `brew install ffmpeg`
+
 ## Setup Steps
 *Note: this is a first pass, there may be odd errors since I wasn't on a pristine box when I wrote it. Please message @cguess with any error messages, it's probably missing dependencies.*
 

--- a/app/models/instagram_post.rb
+++ b/app/models/instagram_post.rb
@@ -11,6 +11,12 @@ class InstagramPost < ApplicationRecord
   # The `TwitterUser` that is the author of this tweet.
   belongs_to :author, class_name: "InstagramUser"
 
+  after_commit on: [:create] do
+    # We only want to create the derivatives once (since you know, it's a media archive we don't
+    # want them to change)
+    self.videos.each { |video| video.video_derivatives! }
+  end
+
   # Returns a +boolean+ on whether this class can handle the URL passed in.
   # All items that are scraped should implement this class
   #

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -11,6 +11,12 @@ class Tweet < ApplicationRecord
   # The `TwitterUser` that is the author of this tweet.
   belongs_to :author, class_name: "TwitterUser"
 
+  after_commit on: [:create] do
+    # We only want to create the derivatives once (since you know, it's a media archive we don't
+    # want them to change)
+    self.videos.each { |video| video.video_derivatives! }
+  end
+
   # Returns a +boolean+ on whether this class can handle the URL passed in.
   # All items that are scraped should implement this class
   #

--- a/app/uploaders/video_uploader.rb
+++ b/app/uploaders/video_uploader.rb
@@ -1,5 +1,12 @@
 # typed: ignore
 
 class VideoUploader < Shrine
-  # plugins and uploading logic
+  Attacher.derivatives do |original|
+    preview = Tempfile.new ["#{SecureRandom.uuid}-preview", ".jpg"]
+
+    video = FFMPEG::Movie.new(original.path)
+    video.screenshot(preview.path)
+
+    { preview: preview }
+  end
 end

--- a/app/views/archive/_item_media_preview.html.erb
+++ b/app/views/archive/_item_media_preview.html.erb
@@ -1,7 +1,11 @@
 <% if item.images.empty? == false %>
 <img src="<%= item.images.first.image_url %>" />
 <% elsif item.videos.empty? == false %>
-<video width="320" height="240" controls>
+<video
+  width="320"
+  height="240"
+  poster="<%= item.videos.first.video_derivatives[:preview].url %>"
+  controls >
   <source src="<%= item.videos.first.video_url %>" type="video/mp4">
   Your browser does not support the video tag.
 </video>

--- a/app/views/instagram_users/show.html.erb
+++ b/app/views/instagram_users/show.html.erb
@@ -29,8 +29,12 @@
           <% if instagram_post.images.empty? == false %>
           <img src="<%= instagram_post.images.first.image_url %>" class="w-40 h-40 mb-5 inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
           <% elsif instagram_post.videos.empty? == false %>
-          <video width="320" height="240" controls>
-            <source src="<%= item.videos.first.video_url %>" type="video/mp4">
+          <video
+            width="320"
+            height="240"
+            poster="<%= instagram_post.videos.first.video_derivatives[:preview].url %>"
+            controls>
+            <source src="<%= instagram_post.videos.first.video_url %>" type="video/mp4">
             Your browser does not support the video tag.
           </video>
           <% end %>

--- a/app/views/twitter_users/show.html.erb
+++ b/app/views/twitter_users/show.html.erb
@@ -31,7 +31,11 @@
           <% if tweet.images.empty? == false %>
           <img src="<%= tweet.images.first.image_url %>" class="w-40 h-40 mb-5 inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
           <% elsif tweet.videos.empty? == false %>
-          <video width="320" height="240" controls>
+          <video
+            width="320"
+            height="240"
+            poster="<%= tweet.videos.first.video_derivatives[:preview].url %>"
+            controls>
             <source src="<%= tweet.videos.first.video_url %>" type="video/mp4">
             Your browser does not support the video tag.
           </video>

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -29,3 +29,4 @@ end
 Shrine.plugin :activerecord
 Shrine.plugin :cached_attachment_data # for retaining the cached file across form redisplays
 Shrine.plugin :restore_cached_data # re-extract metadata when attaching a cached file
+Shrine.plugin :derivatives

--- a/db/migrate/20210628185327_create_twitter_video_preview.rb
+++ b/db/migrate/20210628185327_create_twitter_video_preview.rb
@@ -1,0 +1,10 @@
+# typed: ignore
+
+# Update all twitter videos to have a preview image
+class CreateTwitterVideoPreview < ActiveRecord::Migration[6.1]
+  def change
+    Tweet.all do |tweet|
+      tweet.videos.each { |video| video.video_derivatives! }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_24_171825) do
+ActiveRecord::Schema.define(version: 2021_06_28_185327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/test/models/instagram_post_test.rb
+++ b/test/models/instagram_post_test.rb
@@ -48,4 +48,10 @@ class InstagramPostTest < ActiveSupport::TestCase
     assert_kind_of ArchiveItem, archive_item
     assert_not_nil archive_item.instagram_post.videos
   end
+
+  test "archiving a video creates a preview screenshot" do
+    zorki_instagram_post_video = InstagramMediaSource.extract("https://www.instagram.com/p/CHdIkUVBz3C/?utm_source=ig_embed")
+    archive_item = InstagramPost.create_from_zorki_hash(zorki_instagram_post_video).first
+    assert_not_nil archive_item.instagram_post.videos.first.video_derivatives[:preview]
+  end
 end

--- a/test/models/tweet_test.rb
+++ b/test/models/tweet_test.rb
@@ -53,4 +53,10 @@ class TweetTest < ActiveSupport::TestCase
     assert_kind_of ArchiveItem, archive_item
     assert_not_nil archive_item.tweet.videos
   end
+
+  test "archiving a video creates a preview screenshot" do
+    birdsong_tweet_video = TwitterMediaSource.extract("https://twitter.com/JoeBiden/status/1258817692448051200")
+    archive_item = Tweet.create_from_birdsong_hash(birdsong_tweet_video).first
+    assert_not_nil archive_item.tweet.videos.first.video_derivatives[:preview]
+  end
 end


### PR DESCRIPTION
Generate video preview images whenever a video is uploaded.

This is covered in tests, but you can also view the home page and see the `poster` attribute to a `video` tag.

Closes #50 