### PR TITLE
Update rbenv installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Follow the instructions in any of the repos to properly install it. Make sure to
 
 ##### [Rbenv](https://github.com/rbenv/rbenv)
 *This is the one I (@cguess) use.*
-It's lightweight, well maintained, and works pretty flawlessly. When installing Ruby with rbenv, make sure to keep the source code locally by using the `--keep` flag. E.g. `rbenv install 3.0.1 --keep` 
+It's lightweight, well maintained, and works pretty flawlessly. 
+
+Note: one of the Gems used in this project, `dhash-vips`, uses Ruby source files to speed up image similarity processing. To ensure that rbenv stores the Ruby source files locally, using the `--keep` flag when installing a new Ruby version. E.g. `rbenv install 3.0.1 --keep` 
 
 ##### [RVM](https://rvm.io)
 This is the classic one. Most people I know have moved on to Rbenv, but it works perfectly fine, if not a little heavier than Rbenv is.
@@ -91,7 +93,7 @@ Ubuntu: `sudo apt-get install ffmpeg`
 ## Setup Steps
 *Note: this is a first pass, there may be odd errors since I wasn't on a pristine box when I wrote it. Please message @cguess with any error messages, it's probably missing dependencies.*
 
-1. Install all the prereqs including the latest Ruby version
+1. Install all the prereqs including the latest Ruby version, ensuring Ruby source files are stored locally. 
 1. Clone this repo `git clone https://github.com/TechAndCheck/zenodotus`
 1. Clone the [birdsong](https://github.com/cguess/birdsong) and [zorki](https://github.com/cguess/zorki) repos elsewhere.
 1. Navigate into the project folder `cd zenodotus` (or whatever)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ There's a few prereqs that you need on your machine to run this system. All of t
 
 Things we need to install include (steps below for all this):
 - Homebrew (for MacOS)
-- Ruby (3.0.1 as of writing, but check in [/.ruby-verison](.ruby-version) for the most up to date version)
+- Ruby (3.0.2 as of writing, but check in [/.ruby-verison](.ruby-version) for the most up to date version)
 - Chrome, whatever version is newest
 - Postgresql 13
 - Yarn (1.22.10 as of writing)
@@ -28,7 +28,7 @@ Follow the instructions in any of the repos to properly install it. Make sure to
 *This is the one I (@cguess) use.*
 It's lightweight, well maintained, and works pretty flawlessly. 
 
-Note: one of the Gems used in this project, `dhash-vips`, uses Ruby source files to speed up image similarity processing. To ensure that rbenv stores the Ruby source files locally, using the `--keep` flag when installing a new Ruby version. E.g. `rbenv install 3.0.1 --keep` 
+Note: one of the Gems used in this project, `dhash-vips`, uses Ruby source files to speed up image similarity processing. To ensure that rbenv stores the Ruby source files locally, using the `--keep` flag when installing a new Ruby version. E.g. `rbenv install 3.0.2 --keep` 
 
 ##### [RVM](https://rvm.io)
 This is the classic one. Most people I know have moved on to Rbenv, but it works perfectly fine, if not a little heavier than Rbenv is.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Follow the instructions in any of the repos to properly install it. Make sure to
 
 ##### [Rbenv](https://github.com/rbenv/rbenv)
 *This is the one I (@cguess) use.*
-It's lightweight, well maintained, and works pretty flawlessly.
+It's lightweight, well maintained, and works pretty flawlessly. When installing Ruby with rbenv, make sure to keep the source code locally by using the `--keep` flag. E.g. `rbenv install 3.0.1 --keep` 
 
 ##### [RVM](https://rvm.io)
 This is the classic one. Most people I know have moved on to Rbenv, but it works perfectly fine, if not a little heavier than Rbenv is.


### PR DESCRIPTION
When using rbenv, installing ruby versions with the `--keep` or `-k` flag ensures that Ruby source files are locally available for gems that need them, like `dhash-vips`