### PR TITLE
#71 set up authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ yarn-debug.log*
 # We don't want to check in coverage results
 coverage
 
+.idea/

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "jbuilder", "~> 2.7"
 gem "redis", "~> 4.0"
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
-gem "simple_token_authentication", "~> 1.17.0"
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
@@ -72,10 +71,6 @@ group :development do
 
   # We use Yard for all of our documentation
   gem "yard", require: false
-  
-  # Devise is used for authentication and user management
-  gem 'devise', '~> 4.8.0'
-
 end
 
 group :test do
@@ -146,3 +141,6 @@ gem "ruby-progressbar"
 
 # For validating JSON input on the API
 gem "json_schemer"
+
+# Devise is used for authentication and user management
+gem "devise", "~> 4.8.0"

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "jbuilder", "~> 2.7"
 gem "redis", "~> 4.0"
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
+gem "simple_token_authentication", "~> 1.17.0"
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile
+++ b/Gemfile
@@ -76,8 +76,6 @@ group :development do
   # Devise is used for authentication and user management
   gem 'devise', '~> 4.8.0'
 
-  # letter opener is used for previewing email in-browser
-  gem 'letter_opener'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -136,8 +136,8 @@ gem "streamio-ffmpeg"
 gem "zorki", "0.1.0", git: "https://github.com/cguess/zorki"
 gem "birdsong", "0.1.0", git: "https://github.com/cguess/birdsong"
 
-# gem "zorki", "0.1.0", git: "https://github.com/cguess/zorki"
-# gem "birdsong", "0.1.0", git: "https://github.com/cguess/birdsong"
-
 # A progress bar for our Rake tasks
 gem "ruby-progressbar"
+
+# For validating JSON input on the API
+gem "json_schemer"

--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,12 @@ group :development do
 
   # We use Yard for all of our documentation
   gem "yard", require: false
+  
+  # Devise is used for authentication and user management
+  gem 'devise', '~> 4.8.0'
+
+  # letter opener is used for previewing email in-browser
+  gem 'letter_opener'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,15 +155,15 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
-    launchy (2.5.0)
-      addressable (~> 2.7)
-    letter_opener (1.7.0)
-      launchy (~> 2.2)
     json_schemer (0.2.18)
       ecma-re-validator (~> 0.3)
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       uri_template (~> 0.7)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -183,10 +183,9 @@ GEM
     nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogiri (1.11.7-x86_64-darwin)
-      racc (~> 1.4)
     oauth (0.5.6)
     oj (3.12.1)
+    orm_adapter (0.5.0)
     os (1.1.1)
     parallel (1.20.1)
     parlour (6.0.0)
@@ -423,8 +422,8 @@ DEPENDENCIES
   figaro
   hotwire-rails
   jbuilder (~> 2.7)
-  letter_opener
   json_schemer
+  letter_opener
   listen (~> 3.3)
   os
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       capybara (~> 3.13, < 4)
       websocket-driver (>= 0.6.5)
     ast (2.4.2)
+    bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
@@ -115,6 +116,12 @@ GEM
     concurrent-ruby (1.1.9)
     content_disposition (1.0.0)
     crass (1.0.6)
+    devise (4.8.0)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
     docile (1.4.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
@@ -148,6 +155,10 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     json_schemer (0.2.18)
       ecma-re-validator (~> 0.3)
       hana (~> 1.3)
@@ -238,6 +249,9 @@ GEM
     rbtree (0.4.4)
     redis (4.3.1)
     regexp_parser (2.1.1)
+    responders (3.0.1)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rexml (3.2.5)
     rubocop (1.17.0)
       parallel (~> 1.10)
@@ -363,6 +377,8 @@ GEM
     validate_url (1.0.13)
       activemodel (>= 3.0.0)
       public_suffix
+    warden (1.2.9)
+      rack (>= 2.0.9)
     web-console (4.1.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -396,12 +412,14 @@ DEPENDENCIES
   bullet
   byebug
   capybara (>= 3.26)
+  devise (~> 4.8.0)
   dhash-vips!
   dotenv-rails
   ferrum (~> 0.11)
   figaro
   hotwire-rails
   jbuilder (~> 2.7)
+  letter_opener
   json_schemer
   listen (~> 3.3)
   os
@@ -444,4 +462,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.2.17
+   2.2.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,6 +311,10 @@ GEM
     shrine (3.4.0)
       content_disposition (~> 1.0)
       down (~> 5.1)
+    simple_token_authentication (1.17.0)
+      actionmailer (>= 3.2.6, < 7)
+      actionpack (>= 3.2.6, < 7)
+      devise (>= 3.2, < 6)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -440,6 +444,7 @@ DEPENDENCIES
   sass-rails (>= 6)
   selenium-webdriver
   shrine (~> 3.0)
+  simple_token_authentication (~> 1.17.0)
   simplecov
   sorbet
   sorbet-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
       railties (>= 3.2)
     down (5.2.2)
       addressable (~> 2.5)
+    ecma-re-validator (0.3.0)
+      regexp_parser (~> 2.0)
     erubi (1.10.0)
     erubis (2.7.0)
     ethon (0.14.0)
@@ -136,6 +138,7 @@ GEM
       thor (>= 0.14.0, < 2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hana (1.3.7)
     highline (2.0.3)
     hotwire-rails (0.1.3)
       rails (>= 6.0.0)
@@ -145,6 +148,11 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    json_schemer (0.2.18)
+      ecma-re-validator (~> 0.3)
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      uri_template (~> 0.7)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -167,7 +175,7 @@ GEM
     nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
     oauth (0.5.6)
-    oj (3.11.7)
+    oj (3.12.1)
     os (1.1.1)
     parallel (1.20.1)
     parlour (6.0.0)
@@ -351,6 +359,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
     uniform_notifier (1.14.2)
+    uri_template (0.7.0)
     validate_url (1.0.13)
       activemodel (>= 3.0.0)
       public_suffix
@@ -393,6 +402,7 @@ DEPENDENCIES
   figaro
   hotwire-rails
   jbuilder (~> 2.7)
+  json_schemer
   listen (~> 3.3)
   os
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,10 +160,6 @@ GEM
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       uri_template (~> 0.7)
-    launchy (2.5.0)
-      addressable (~> 2.7)
-    letter_opener (1.7.0)
-      launchy (~> 2.2)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -310,10 +306,6 @@ GEM
     shrine (3.4.0)
       content_disposition (~> 1.0)
       down (~> 5.1)
-    simple_token_authentication (1.17.0)
-      actionmailer (>= 3.2.6, < 7)
-      actionpack (>= 3.2.6, < 7)
-      devise (>= 3.2, < 6)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -423,7 +415,6 @@ DEPENDENCIES
   hotwire-rails
   jbuilder (~> 2.7)
   json_schemer
-  letter_opener
   listen (~> 3.3)
   os
   pg (~> 1.1)
@@ -443,7 +434,6 @@ DEPENDENCIES
   sass-rails (>= 6)
   selenium-webdriver
   shrine (~> 3.0)
-  simple_token_authentication (~> 1.17.0)
   simplecov
   sorbet
   sorbet-rails

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ A faster image manipulation library than ImageMagick. `brew install vips`. Note:
 1. Install all the gems `bundle install`. This may take a few minutes
 1. Make sure Postgres is running
 1. Set up the database: `rails db:create && rails db:setup`
+1. Set up your environment variables.
+  1. If you're on local development `touch application.yml` and ask someone else for their's
+  1. If you're setting up production make sure the environment variables are set properly
 1. Open two terminal windows up
 1. In one, run `./bin/webpack-dev-server`
 1. In another, run `rails s`

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,12 +3,30 @@ class ApplicationController < ActionController::Base
   extend T::Sig
   extend T::Helpers
 
-  acts_as_token_authentication_handler_for User
   protect_from_forgery with: :null_session, if: :json_request?, prepend: true
 
-  protected
+protected
 
+  sig { void }
   def json_request?
     request.format.json?
+  end
+
+  sig { void }
+  def authenticate_user_from_api_key!
+    api_key = params[:api_key].presence
+    hashed_api_key = Digest::SHA256.hexdigest(api_key)
+    api_key = hashed_api_key && ApiKey.find_by_hashed_api_key(hashed_api_key)
+
+    # Devise.secure_compare prevents timing attacks
+    if api_key && Devise.secure_compare(api_key.hashed_api_key, hashed_api_key)
+      sign_in(api_key.user, store: false)
+    else
+      render json: {
+        error: "Unauthorized credentials, please check your API Key"
+      }, status: :unauthorized
+      return false
+    end
+    true
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,5 +4,11 @@ class ApplicationController < ActionController::Base
   extend T::Helpers
 
   acts_as_token_authentication_handler_for User
+  protect_from_forgery with: :null_session, if: :json_request?
 
+  protected
+
+  def json_request?
+    request.format.json?
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   extend T::Helpers
 
   acts_as_token_authentication_handler_for User
-  protect_from_forgery with: :null_session, if: :json_request?
+  protect_from_forgery with: :null_session, if: :json_request?, prepend: true
 
   protected
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,22 +2,4 @@
 class ApplicationController < ActionController::Base
   extend T::Sig
   extend T::Helpers
-
-  # Return a class that can handle a given +url+
-  sig { params(url: String).returns(T.nilable(Class)) }
-  def model_for_url(url)
-    # Load all models so we can inspect them
-    Zeitwerk::Loader.eager_load_all
-
-    # Get all models conforming to ApplicationRecord, and then check if they implement the magic
-    # function.
-    models = ApplicationRecord.descendants.select do |model|
-      if model.respond_to? :can_handle_url?
-        model.can_handle_url?(url)
-      end
-    end
-
-    # We'll always choose the first one
-    models.first
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,7 @@
 class ApplicationController < ActionController::Base
   extend T::Sig
   extend T::Helpers
+
+  acts_as_token_authentication_handler_for User
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,12 +14,20 @@ protected
 
   sig { void }
   def authenticate_user_from_api_key!
+    if params[:api_key].blank?
+      render json: {
+        error: "Unauthorized credentials, please check your API Key"
+      }, status: :unauthorized
+      return false
+    end
+
     api_key = params[:api_key].presence
-    hashed_api_key = Digest::SHA256.hexdigest(api_key)
+    hashed_api_key = ZenoEncryption.hash_string(api_key)
     api_key = hashed_api_key && ApiKey.find_by_hashed_api_key(hashed_api_key)
 
     # Devise.secure_compare prevents timing attacks
     if api_key && Devise.secure_compare(api_key.hashed_api_key, hashed_api_key)
+      api_key.update_with_use(request)
       sign_in(api_key.user, store: false)
     else
       render json: {

--- a/app/controllers/archive_controller.rb
+++ b/app/controllers/archive_controller.rb
@@ -39,7 +39,7 @@ class ArchiveController < ApplicationController
     # end
     typed_params = TypedParams[SubmitUrlParams].new.extract!(params)
     url = typed_params.url_to_archive
-    object_model = model_for_url(url)
+    object_model = ArchiveItem.model_for_url(url)
     begin
       object_model.create_from_url(url)
     rescue StandardError => e

--- a/app/controllers/archive_controller.rb
+++ b/app/controllers/archive_controller.rb
@@ -2,6 +2,17 @@
 
 class ArchiveController < ApplicationController
   # It's the index, list all the archived items
+
+  before_action :require_login, only: [:submit_url ]
+
+  def require_login
+    unless user_signed_in?
+      respond_to do |format|
+        format.html { redirect_to new_user_session_path }
+      end
+    end
+  end
+
   sig { void }
   def index
     @archive_items = ArchiveItem.includes({ archivable_item: [:author, :images, :videos] })
@@ -21,6 +32,10 @@ class ArchiveController < ApplicationController
   # @params {url_to_archive} the url to pull in
   sig { void }
   def submit_url
+    # unless user_signed_in?
+    #   format.html { redirect_to :new_user_session_path }
+    #   return
+    # end
     typed_params = TypedParams[SubmitUrlParams].new.extract!(params)
     url = typed_params.url_to_archive
     object_model = model_for_url(url)

--- a/app/controllers/archive_controller.rb
+++ b/app/controllers/archive_controller.rb
@@ -3,7 +3,7 @@
 class ArchiveController < ApplicationController
   # It's the index, list all the archived items
 
-  before_action :authenticate_user!
+  # before_action :authenticate_user!
   # before_action :require_login, only: [:submit_url ]
 
   # def require_login

--- a/app/controllers/archive_controller.rb
+++ b/app/controllers/archive_controller.rb
@@ -3,15 +3,16 @@
 class ArchiveController < ApplicationController
   # It's the index, list all the archived items
 
-  before_action :require_login, only: [:submit_url ]
+  before_action :authenticate_user!
+  # before_action :require_login, only: [:submit_url ]
 
-  def require_login
-    unless user_signed_in?
-      respond_to do |format|
-        format.html { redirect_to new_user_session_path }
-      end
-    end
-  end
+  # def require_login
+  #   unless user_signed_in?
+  #     respond_to do |format|
+  #       format.html { redirect_to new_user_session_path }
+  #     end
+  #   end
+  # end
 
   sig { void }
   def index

--- a/app/controllers/image_search_controller.rb
+++ b/app/controllers/image_search_controller.rb
@@ -1,6 +1,8 @@
 # typed: ignore
 
 class ImageSearchController < ApplicationController
+
+  before_action :authenticate_user!
   # A class representing the allowed params into the `index` endpoint
   class IndexUrlParams < T::Struct
     const :q_id, T.nilable(String)

--- a/app/controllers/image_search_controller.rb
+++ b/app/controllers/image_search_controller.rb
@@ -2,7 +2,7 @@
 
 class ImageSearchController < ApplicationController
 
-  before_action :authenticate_user!
+  # before_action :authenticate_user!
   # A class representing the allowed params into the `index` endpoint
   class IndexUrlParams < T::Struct
     const :q_id, T.nilable(String)

--- a/app/controllers/ingest_controller.rb
+++ b/app/controllers/ingest_controller.rb
@@ -1,0 +1,101 @@
+# typed: ignore
+
+class IngestController < ApplicationController
+  class ApiResponseCodes < T::Enum
+    extend T::Sig
+
+    enums do
+      Success = new
+    end
+
+    sig { returns(Integer) }
+    def code
+      case self
+      when Success then 20
+      else T.absurd(self)
+      end
+    end
+
+    sig { returns(String) }
+    def message
+      case self
+      when Success then "Successfully archived media object"
+      else T.absurd(self)
+      end
+    end
+  end
+
+  class ApiErrors < T::Enum
+    extend T::Sig
+
+    enums do
+      JSONParseError = new
+      JSONValidationError = new
+    end
+
+    sig { returns(Integer) }
+    def code
+      case self
+      when JSONParseError then 10
+      when JSONValidationError then 11
+      else T.absurd(self)
+      end
+    end
+
+    sig { returns(String) }
+    def message
+      case self
+      when JSONParseError then "Error parsing JSON, invalid JSON"
+      when JSONValidationError then "Error parsing JSON, JSON does not conform to schema"
+      else T.absurd(self)
+      end
+    end
+  end
+
+  # A class representing the allowed params into the `submit_media_review` endpoint
+  class SubmitMediaReviewParams < T::Struct
+    const :media_review_json, String
+  end
+
+  # Submit MediaReview data, which the URL will be scraped from
+  sig { void }
+  def submit_media_review
+    # TODO: Spin off an active job to handle this
+    typed_params = TypedParams[SubmitMediaReviewParams].new.extract!(params)
+    media_review_json = JSON.parse(typed_params.media_review_json)
+
+    unless validate_media_review(media_review_json)
+      error = {
+        error_code: ApiErrors::JSONValidationError.code,
+        error: ApiErrors::JSONValidationError.message,
+        information: "" }
+      render(json: error, status: 400) && return
+    end
+
+    saved_object = ArchiveItem.create_from_media_review(media_review_json)
+    response = {
+      response_code: ApiResponseCodes::Success.code,
+      response: ApiResponseCodes::Success.message,
+      media_object_id: saved_object.id
+    }
+
+    render json: response, status: 200
+  rescue JSON::ParserError
+    error = {
+      error_code: ApiErrors::JSONParseError.code,
+      error: ApiErrors::JSONParseError.message,
+      information: "" }
+    render(json: error, status: 400)
+  end
+
+private
+
+  # Validate MediaReview that was passed in
+  sig { params(media_review: Hash).returns(T::Boolean) }
+  def validate_media_review(media_review)
+    schema = File.open("public/json-schemas/claim-review-schema.json").read
+    JSONSchemer.schema(schema).valid?(media_review)
+  rescue StandardError
+    false
+  end
+end

--- a/app/controllers/ingest_controller.rb
+++ b/app/controllers/ingest_controller.rb
@@ -1,6 +1,8 @@
 # typed: ignore
 
 class IngestController < ApplicationController
+  before_action :authenticate_user_from_api_key!
+
   class ApiResponseCodes < T::Enum
     extend T::Sig
 

--- a/app/controllers/ingest_controller.rb
+++ b/app/controllers/ingest_controller.rb
@@ -62,6 +62,7 @@ class IngestController < ApplicationController
   # Submit MediaReview data, which the URL will be scraped from
   sig { void }
   def submit_media_review
+    # byebug
     # TODO: Spin off an active job to handle this
     typed_params = TypedParams[SubmitMediaReviewParams].new.extract!(params)
     media_review_json = JSON.parse(typed_params.media_review_json)

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,22 @@
+class SettingsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    puts "what's there to say?"
+  end
+
+  def approveUserRequest
+    user = User.find(params[:user])
+    user.update(approved: true)
+
+  end
+
+  def denyUserRequest
+    user = User.find(params[:user])
+    user.destroy
+  end
+
+  def admin
+
+  end
+end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,5 +1,5 @@
 class SettingsController < ApplicationController
-  before_action :authenticate_user!
+  # before_action :authenticate_user!
 
   def index
     puts "what's there to say?"

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # TODO: Send email to admins when a user tries to register?
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,9 +9,14 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   # POST /resource/sign_in
-  # def create
-  #   super
-  # end
+  def create
+    self.resource = warden.authenticate!(auth_options)
+    set_flash_message!(:notice, :signed_in)
+    sign_in(resource_name, resource)
+    yield resource if block_given?
+    respond_with resource, location: after_sign_in_path_for(resource)
+    # super
+  end
 
   # DELETE /resource/sign_out
   # def destroy

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -6,6 +6,10 @@ class ApiKey < ApplicationRecord
 
   def create_api_key
     @api_key = SecureRandom.alphanumeric(30)
-    self.hashed_api_key = Digest::SHA512.hexdigest @api_key
+    self.hashed_api_key = ZenoEncryption.hash_string(@api_key)
+  end
+
+  def update_with_use(request)
+    self.update({ last_used: Time.now })
   end
 end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,11 @@
+class ApiKey < ApplicationRecord
+  belongs_to :user, required: true
+  attr_reader :api_key
+
+  before_create :create_api_key
+
+  def create_api_key
+    @api_key = SecureRandom.alphanumeric(30)
+    self.hashed_api_key = Digest::SHA512.hexdigest @api_key
+  end
+end

--- a/app/models/archive_item.rb
+++ b/app/models/archive_item.rb
@@ -6,6 +6,14 @@ class ArchiveItem < ApplicationRecord
   delegate :images, to: :archivable_item
   delegate :videos, to: :archivable_item
 
+  # Creates an +ArchiveEntity
+  #
+  # @!scope class
+  # @params media_review String a block of json media_review
+  # @return a Boolean on whether or not the class can handle the URL
+  def self.create_from_media_review(media_review)
+  end
+
   # Note: You may want to use `alias` or `alias_method` here instead of the following functions
   # it *does not* work. Probably because of the `delegated_type` metaprogramming, but hacking that
   # is a bad idea.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  acts_as_token_authenticatable
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,13 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :confirmable, :timeoutable, :trackable,
-         :lockable
+         :confirmable, :trackable, :lockable
+
+  def active_for_authentication?
+    super && approved?
+  end
+
+  def inactive_message
+    approved ? super : :not_approved   # see config/locales/devise
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,8 @@
+class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable,
+         :confirmable, :timeoutable, :trackable,
+         :lockable
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,6 @@ class User < ApplicationRecord
   end
 
   def inactive_message
-    approved ? super : :not_approved   # see config/locales/devise
+    approved? ? super : :not_approved   # see config/locales/devise
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  acts_as_token_authenticatable
+  has_many :api_keys, dependent: :destroy
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -18,7 +18,7 @@
           <%= link_to "Login", new_user_session_path%>
         <% end %>
       </div>
-      <% if current_user.admin? %>
+      <% if user_signed_in? and current_user.admin? %>
         <%= link_to "Settings", settings_path %>
       <% end %>
     </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -18,6 +18,9 @@
           <%= link_to "Login", new_user_session_path%>
         <% end %>
       </div>
+      <% if current_user.admin? %>
+        <%= link_to "Settings", settings_path %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,15 +11,18 @@
       <div class="flex-shrink mr-6">
         <a href="#">All Collected Media</a>
       </div>
-      <div class="flex-shrink mr-6">
-        <% if user_signed_in? %>
-          <%= button_to "Logout", destroy_user_session_path, method: :delete%>
-        <% else %>
-          <%= link_to "Login", new_user_session_path%>
-        <% end %>
-      </div>
       <% if user_signed_in? and current_user.admin? %>
         <%= link_to "Settings", settings_path %>
+      <% end %>
+    </div>
+  </div>
+  <div class="flex flex-row">
+    <div class="flex-shrink mr-6">
+      <% if user_signed_in? %>
+        <%= button_to "Logout", destroy_user_session_path, method: :delete %>
+      <% else %>
+        <%= link_to "Login", new_user_session_path %>
+        <%= link_to "Register", new_user_registration_path, class: "border rounded px-3 py-2 ml-3 bg-white" %>
       <% end %>
     </div>
   </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,6 +11,13 @@
       <div class="flex-shrink mr-6">
         <a href="#">All Collected Media</a>
       </div>
+      <div class="flex-shrink mr-6">
+        <% if user_signed_in? %>
+          <%= button_to "Logout", destroy_user_session_path, method: :delete%>
+        <% else %>
+          <%= link_to "Login", new_user_session_path%>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,10 @@
   </head>
 
   <body class="bg-green-50">
+
+    <p class="notice"><%= notice %></p> <!-- Devise -->
+    <p class="alert"><%= alert %></p>
+
     <%= render "layouts/header" %>
     <div class="flex flex-col lg:mx-auto mt-4 ml-5 mr-5 max-w-screen-xl">
       <%= render "layouts/flashes" %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,0 +1,50 @@
+
+<div id="nav" class="h-full w-250px fixed left-0  overflow-x-hidden pt-60px z-1">
+<!--  <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>-->
+  <a class="block" href="#">Profile</a>
+  <a class="block" href="#">App</a>
+  <% if current_user.admin? %>
+    <a class="block" href="#">Admin</a>
+  <%end %>
+</div>
+<% if current_user.admin? %>
+  <table>
+    <tr>
+      <th>Email</th>
+      <th>Request</th>
+      <th>Action</th>
+    </tr>
+    <% User.all.where(approved: false).each do | user| %>
+      <tr>
+        <td><%= user.email %>, <%=user.approved %></td>
+        <td>please let me be in the zenodotus demo I need the fact checker clout</td>
+        <td>
+          <%= button_to "approve", approve_request_path, params: {user: user}  %>
+          <%= button_to "deny",  deny_request_path, params: {user: user}  %>
+        </td>
+      </tr>
+    <% end %>
+</table>
+
+<!--  User management-->
+<!--  Users:-->
+<!--  <table>-->
+<!--    <tr>-->
+<!--      <th>Email</th>-->
+<!--      <th>Action</th>-->
+<!--    </tr>-->
+    <%# User.all.each do | user| %>
+<!--      <tr>-->
+<!--        <td><%#= user.email %></td>-->
+<!--        <td>-->
+          <%#= button_to "delete",  deny_request_path, params: {user: user}  %>
+<!--        </td>-->
+<!--      </tr>-->
+    <%# end %>
+<!--  </table>-->
+
+<!--  Find User:-->
+  <%#= form_with url: user_search_path %>
+
+<%# else %>
+<% end %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,31 +1,43 @@
-
 <div id="nav" class="h-full w-250px fixed left-0  overflow-x-hidden pt-60px z-1">
 <!--  <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>-->
   <a class="block" href="#">Profile</a>
   <a class="block" href="#">App</a>
   <% if current_user.admin? %>
-    <a class="block" href="#">Admin</a>
+    <a class="block" href="#" onclick="document.getElementById('approvals').classList.toggle('invisible')">Approvals</a>
+    <a class="block">API key</a>
   <%end %>
 </div>
 <% if current_user.admin? %>
-  <table>
-    <tr>
-      <th>Email</th>
-      <th>Request</th>
-      <th>Action</th>
-    </tr>
-    <% User.all.where(approved: false).each do | user| %>
+  <h1>User approvals</h1>
+  <table id="approvals" class="table-auto">
+    <thead>
       <tr>
-        <td><%= user.email %>, <%=user.approved %></td>
-        <td>please let me be in the zenodotus demo I need the fact checker clout</td>
-        <td>
-          <%= button_to "approve", approve_request_path, params: {user: user}  %>
-          <%= button_to "deny",  deny_request_path, params: {user: user}  %>
-        </td>
+        <th class="border">Email</th>
+        <th class="border">Request</th>
+        <th class="border">Action</th>
       </tr>
-    <% end %>
-</table>
-  API key: <%=current_user.authentication_token %>
+    </thead>
+    <tbody>
+      <% User.all.where(approved: false).each do | user| %>
+        <tr class="border text-gray-600 hover:text-black">
+          <td><%= user.email %>, <%=user.approved %></td>
+          <td>Please let me be in the zenodotus demo I need the fact checker clout</td>
+          <td>
+            <!-- re-render from controller on approve/deny? -->
+            <%= button_to "approve", approve_request_path, params: {user: user}, class:"float-left bg-blue-400 hover:bg-blue-500 p-2 text-white hover:shadow-lg text-xs font-thin" %>
+            <%= button_to "deny",  deny_request_path, params: {user: user}, class:"float-left bg-red-400 hover:bg-red-500 p-2 text-white hover:shadow-lg text-xs font-thin"  %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <br>
+  <hr>
+  <div id="api">
+    <h1>API Key</h1>
+    API key: <%=current_user.authentication_token %>
+  </div>
 
 <!--  User management-->
 <!--  Users:-->

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -25,6 +25,7 @@
       </tr>
     <% end %>
 </table>
+  API key: <%=current_user.authentication_token %>
 
 <!--  User management-->
 <!--  Users:-->

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -34,10 +34,6 @@
 
   <br>
   <hr>
-  <div id="api">
-    <h1>API Key</h1>
-    API key: <%=current_user.authentication_token %>
-  </div>
 
 <!--  User management-->
 <!--  Users:-->

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "users/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/users/mailer/email_changed.html.erb
+++ b/app/views/users/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/users/mailer/password_change.html.erb
+++ b/app/views/users/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/users/mailer/unlock_instructions.html.erb
+++ b/app/views/users/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "users/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "users/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,0 +1,43 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "users/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "current-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+<%= link_to "Back", :back %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,0 +1,29 @@
+<h2>Sign up</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= render "users/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Log in</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "current-password" %>
+  </div>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,26 +1,79 @@
-<h2>Log in</h2>
-
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+<div class="h-auto flex items-center justify-center mt-14">
+  <div class="z-10">
+    <div id="login-card" class="px-5 text-center bg-gray-400 rounded-lg shadow-md w-full flex flex-col justify-center items-center space-y-4 pb-10">
+      <div
+        class="relative w-20 bg-pink-200 mx-auto rounded-full p-3 shadow-md"
+        style="top: -2.5rem;"
+      >
+        <%= image_tag "icon.svg" %>
+      </div>
+      <div class="text-3xl font-bold text-pink-200">
+        Zenodotus
+      </div>
+      <%= form_for(
+            resource,
+            as: resource_name,
+            url: session_path(resource_name),
+            html: {
+              class: "
+            h-40
+            w-full
+            flex
+            flex-col
+            justify-center
+            items-center space-y-4
+          ",
+              'data-turbo': "false"
+            }
+          ) do |f|
+      %>
+        <%= f.email_field(
+              :email,
+              autofocus: true,
+              autocomplete: "email",
+              placeholder: "Email Address",
+              class: "
+                rounded-lg
+                focus:outline-none
+                focus:ring-4
+                focus:ring-green-300
+                focus:ring-opacity-50
+                py-1.5
+                px-2
+                text-gray-800
+                placeholder-gray-400
+                shadow-md"
+            ) %>
+        <%= f.password_field(
+              :password,
+              autocomplete: "current-password",
+              placeholder: "Password",
+              class: "
+                rounded-lg
+                focus:outline-none
+                focus:ring-4
+                focus:ring-green-300
+                focus:ring-opacity-50
+                py-1.5
+                px-2
+                text-gray-800
+                placeholder-gray-400
+                shadow-md"
+            ) %>
+        <%= f.submit(
+              "Log in",
+              class: "
+            rounded-lg
+            py-1.5
+            px-2
+            bg-green-500
+            hover:bg-green-400
+            text-gray-50
+            shadow-md"
+            ) %>
+      <% end %>
+      <%= render "devise/shared/links" %>
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
+</div>
 
-<%= render "users/shared/links" %>

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+  <% end %>
+<% end %>

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "users/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,6 @@ module Zenodotus
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
+    config.eager_load_paths << Rails.root.join("lib/utilities")
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,6 +49,11 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,10 +49,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-
-  config.action_mailer.delivery_method = :letter_opener
-  config.action_mailer.perform_deliveries = true
+  config.action_mailer.perform_deliveries = false
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+# Assuming you have not yet modified this file, each configuration option below
+# is set to its default value. Note that some are commented out while others
+# are not: uncommented lines are intended to protect your configuration from
+# breaking changes in upgrades (i.e., in the event that future versions of
+# Devise change the default values for those options).
+#
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '598f8e165d339918744087402c6c515ef14ea96122f3fc3606bf77cf77fab80ca92a6a0b75f55e83a5fd724cc9a471ae3271a64df90de9d88733730da4070300'
+
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication.
+  # For API-only applications to support authentication "out-of-the-box", you will likely want to
+  # enable this with :database unless you are using a custom strategy.
+  # The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  # The number of stretches used for generating the hashed password are stored
+  # with the hashed password. This allows you to change the stretches without
+  # invalidating existing passwords.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = 'aeadf8eed8117b876cf8a05809ee799cd2c75bb05de46564b93779fcc270ea90a9f12f6bfbd22d7b6e41cdfb2b718a81538a42864ed56f970bfc8acef4b4eaed'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day.
+  # You can also set it to nil, which will allow the user to access the website
+  # without confirming their account.
+  # Default is 0.days, meaning the user cannot access the website without
+  # confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Turbolinks configuration
+  # If your app is using Turbolinks, Turbolinks::Controller needs to be included to make redirection work correctly:
+  #
+  # ActiveSupport.on_load(:devise_failure_app) do
+  #   include Turbolinks::Controller
+  # end
+
+  # ==> Configuration for :registerable
+
+  # When set to false, does not sign a user in automatically after their password is
+  # changed. Defaults to true, so a user is signed in automatically after changing a password.
+  # config.sign_in_after_change_password = true
+end

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -1,0 +1,5 @@
+Figaro.require_keys("TWITTER_BEARER_TOKEN", "INSTAGRAM_USER_NAME", "INSTAGRAM_PASSWORD")
+
+# This is the salt value used to encrypt various things, you can generate one by running
+# `rails secret`
+Figaro.require_keys("KEY_ENCRYPTION_SALT")

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,5 +3,5 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :api_key
 ]

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -16,6 +16,8 @@ en:
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
+      user:
+        not_approved: "You have signed up successfully but your account has not been approved by an admin yet"
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"
@@ -37,10 +39,6 @@ en:
       updated: "Your password has been changed successfully. You are now signed in."
       updated_not_active: "Your password has been changed successfully."
     registrations:
-      user:
-        signed_up_but_not_approved: "You have signed up successfully but your account has not been approved by an admin yet"
-        failure:
-          not_approved: "Your account has not been approved by an admin yet"
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -37,6 +37,10 @@ en:
       updated: "Your password has been changed successfully. You are now signed in."
       updated_not_active: "Your password has been changed successfully."
     registrations:
+      user:
+        signed_up_but_not_approved: "You have signed up successfully but your account has not been approved by an admin yet"
+        failure:
+          not_approved: "Your account has not been approved by an admin yet"
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
@@ -45,6 +49,9 @@ en:
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
       updated: "Your account has been updated successfully."
       updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+      signed_up_but_not_approved: "You have signed up successfully but your account has not been approved by an admin yet"
+      failure:
+        not_approved: "Your account has not been approved by an admin yet"
     sessions:
       signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # typed: false
 Rails.application.routes.draw do
+  devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   # root "login#index"
   root "archive#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # typed: false
 Rails.application.routes.draw do
   devise_for :users
+
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   # root "login#index"
   root "archive#index"
@@ -12,6 +13,10 @@ Rails.application.routes.draw do
 
   get "/image_search", to: "image_search#index", as: "image_search"
   post "/image_search", to: "image_search#search", as: "image_search_submit"
+
+  get "/settings", to: "settings#index", as: "settings"
+  post "/settings/approve", to: "settings#approveUserRequest", as: "approve_request"
+  post "/settings/deny", to: "settings#denyUserRequest", as: "deny_request"
 
   resources :twitter_users, only: [:show]
   resources :instagram_users, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   get "/archive/add", to: "archive#add"
   post "/archive/add", to: "archive#submit_url"
 
+  post "/ingest/submit_mediareview", to: "ingest#submit_mediareview"
+
   get "/image_search", to: "image_search#index", as: "image_search"
   post "/image_search", to: "image_search#search", as: "image_search_submit"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get "/archive/add", to: "archive#add"
   post "/archive/add", to: "archive#submit_url"
 
-  post "/ingest/submit_mediareview", to: "ingest#submit_mediareview"
+  post "/ingest/submit_media_review", to: "ingest#submit_media_review", as: "ingest_api"
 
   get "/image_search", to: "image_search#index", as: "image_search"
   post "/image_search", to: "image_search#search", as: "image_search_submit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 # typed: false
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users,
+             controllers: {
+               sessions: "users/sessions"
+             }
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   # root "login#index"

--- a/db/migrate/20210721225247_remove_null_constraint_from_instagram_user_url.rb
+++ b/db/migrate/20210721225247_remove_null_constraint_from_instagram_user_url.rb
@@ -1,0 +1,7 @@
+# typed: ignore
+
+class RemoveNullConstraintFromInstagramUserUrl < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :instagram_users, :url, true
+  end
+end

--- a/db/migrate/20210730143649_devise_create_users.rb
+++ b/db/migrate/20210730143649_devise_create_users.rb
@@ -1,11 +1,8 @@
-# typed: ignore
 # frozen_string_literal: true
 
 class DeviseCreateUsers < ActiveRecord::Migration[6.1]
   def change
-    create_table :users do |t|
-      t.string   :name
-
+    create_table :users, id: :uuid do |t|
       ## Database authenticatable
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""

--- a/db/migrate/20210730143649_devise_create_users.rb
+++ b/db/migrate/20210730143649_devise_create_users.rb
@@ -1,3 +1,4 @@
+# typed: ignore
 # frozen_string_literal: true
 
 class DeviseCreateUsers < ActiveRecord::Migration[6.1]

--- a/db/migrate/20210803154845_add_approved_to_user.rb
+++ b/db/migrate/20210803154845_add_approved_to_user.rb
@@ -1,0 +1,5 @@
+class AddApprovedToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :approved, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20210803154845_add_approved_to_user.rb
+++ b/db/migrate/20210803154845_add_approved_to_user.rb
@@ -1,5 +1,0 @@
-class AddApprovedToUser < ActiveRecord::Migration[6.1]
-  def change
-    add_column :users, :approved, :boolean, default: false, null: false
-  end
-end

--- a/db/migrate/20210803182641_add_admin_aproved_to_users.rb
+++ b/db/migrate/20210803182641_add_admin_aproved_to_users.rb
@@ -1,3 +1,5 @@
+# typed: ignore
+
 class AddAdminAprovedToUsers < ActiveRecord::Migration[6.1]
   def change
     add_column :users, :approved, :boolean, default: false, null: false

--- a/db/migrate/20210803182641_add_admin_aproved_to_users.rb
+++ b/db/migrate/20210803182641_add_admin_aproved_to_users.rb
@@ -1,0 +1,6 @@
+class AddAdminAprovedToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :approved, :boolean, default: false, null: false
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20210804201517_add_authentication_token_to_users.rb
+++ b/db/migrate/20210804201517_add_authentication_token_to_users.rb
@@ -1,0 +1,6 @@
+class AddAuthenticationTokenToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :authentication_token, :string, limit: 30
+    add_index :users, :authentication_token, unique: true
+  end
+end

--- a/db/migrate/20210804201517_add_authentication_token_to_users.rb
+++ b/db/migrate/20210804201517_add_authentication_token_to_users.rb
@@ -1,6 +1,0 @@
-class AddAuthenticationTokenToUsers < ActiveRecord::Migration[6.1]
-  def change
-    add_column :users, :authentication_token, :string, limit: 30
-    add_index :users, :authentication_token, unique: true
-  end
-end

--- a/db/migrate/20210811142854_create_api_keys.rb
+++ b/db/migrate/20210811142854_create_api_keys.rb
@@ -1,0 +1,15 @@
+# typed: ignore
+
+class CreateApiKeys < ActiveRecord::Migration[6.1]
+  def change
+    create_table :api_keys, id: :uuid do |t|
+      t.string :hashed_api_key
+      t.references :user, type: :uuid, foreign_key: true
+      t.date :last_used
+      t.jsonb :usage_logs
+      t.timestamps
+
+      t.index :hashed_api_key
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_19_191103) do
+ActiveRecord::Schema.define(version: 2021_07_21_225247) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 2021_07_19_191103) do
     t.integer "following_count", null: false
     t.boolean "verified", null: false
     t.text "profile", null: false
-    t.string "url", null: false
+    t.string "url"
     t.string "profile_image_url", null: false
     t.jsonb "profile_image_data"
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_30_143649) do
+ActiveRecord::Schema.define(version: 2021_08_03_154845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -143,6 +143,7 @@ ActiveRecord::Schema.define(version: 2021_07_30_143649) do
     t.datetime "locked_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "approved", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_21_225247) do
+ActiveRecord::Schema.define(version: 2021_07_30_143649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -123,8 +123,7 @@ ActiveRecord::Schema.define(version: 2021_07_21_225247) do
     t.index ["tweet_id"], name: "index_twitter_videos_on_tweet_id"
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "name"
+  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_03_154845) do
+ActiveRecord::Schema.define(version: 2021_08_03_182641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -144,6 +144,7 @@ ActiveRecord::Schema.define(version: 2021_08_03_154845) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "approved", default: false, null: false
+    t.boolean "admin", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_04_201517) do
+ActiveRecord::Schema.define(version: 2021_08_11_142854) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "api_keys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "hashed_api_key"
+    t.uuid "user_id"
+    t.date "last_used"
+    t.jsonb "usage_logs"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["hashed_api_key"], name: "index_api_keys_on_hashed_api_key"
+    t.index ["user_id"], name: "index_api_keys_on_user_id"
+  end
 
   create_table "archive_entities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "archivable_entity_id", null: false
@@ -145,14 +156,13 @@ ActiveRecord::Schema.define(version: 2021_08_04_201517) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "approved", default: false, null: false
     t.boolean "admin", default: false, null: false
-    t.string "authentication_token", limit: 30
-    t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "api_keys", "users"
   add_foreign_key "instagram_images", "instagram_posts"
   add_foreign_key "instagram_videos", "instagram_posts"
   add_foreign_key "twitter_images", "tweets"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_03_182641) do
+ActiveRecord::Schema.define(version: 2021_08_04_201517) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -145,6 +145,8 @@ ActiveRecord::Schema.define(version: 2021_08_03_182641) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "approved", default: false, null: false
     t.boolean "admin", default: false, null: false
+    t.string "authentication_token", limit: 30
+    t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,7 +16,7 @@ User.create([{
 {
   email: "user@example.com",
   password: "password123",
-  approved: true,
+  approved: false,
   admin: false,
   confirmed_at: Time.now
 }])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,5 +10,13 @@ User.create([{
   email: "admin@example.com",
   password: "password123",
   approved: true,
+  admin: true,
+  confirmed_at: Time.now
+},
+{
+  email: "user@example.com",
+  password: "password123",
+  approved: true,
+  admin: false,
   confirmed_at: Time.now
 }])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,3 +6,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+User.create([{
+  email: "admin@example.com",
+  password: "password123",
+  approved: true,
+  confirmed_at: Time.now
+}])

--- a/lib/utilities/zeno_encryption.rb
+++ b/lib/utilities/zeno_encryption.rb
@@ -9,6 +9,8 @@ class ZenoEncryption
   # @returns String the Sha512 hash value of `string`
   sig { params(string: String).returns(String) }
   def self.hash_string(string)
+    # Tack on a salt for better encryption and to prevent rainbow attacks
+    string = Figaro.env.KEY_ENCRYPTION_SALT + string
     Digest::SHA512.hexdigest(string)
   end
 end

--- a/lib/utilities/zeno_encryption.rb
+++ b/lib/utilities/zeno_encryption.rb
@@ -1,0 +1,14 @@
+# typed: true
+
+class ZenoEncryption
+  extend T::Sig
+  extend T::Helpers
+
+  # Hash a string using Sha512 (and eventually a salt)
+  # @param string String the string to hash
+  # @returns String the Sha512 hash value of `string`
+  sig { params(string: String).returns(String) }
+  def self.hash_string(string)
+    Digest::SHA512.hexdigest(string)
+  end
+end

--- a/public/json-schemas/claim-review-schema.json
+++ b/public/json-schemas/claim-review-schema.json
@@ -1,0 +1,156 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/Welcome7",
+    "definitions": {
+        "Welcome7": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "@context": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ]
+                },
+                "@type": {
+                    "type": "string"
+                },
+                "datePublished": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ]
+                },
+                "author": {
+                    "$ref": "#/definitions/Author"
+                },
+                "mediaAuthenticityCategory": {
+                    "type": "string"
+                },
+                "originalMediaContextDescription": {
+                    "type": "string"
+                },
+                "itemReviewed": {
+                    "$ref": "#/definitions/ItemReviewed"
+                }
+            },
+            "required": [
+                "@context",
+                "@type",
+                "author",
+                "datePublished",
+                "itemReviewed",
+                "mediaAuthenticityCategory",
+                "originalMediaContextDescription",
+                "url"
+            ],
+            "title": "Welcome7"
+        },
+        "Author": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "@type": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ]
+                }
+            },
+            "required": [
+                "@type",
+                "name",
+                "url"
+            ],
+            "title": "Author"
+        },
+        "ItemReviewed": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "@type": {
+                    "type": "string"
+                },
+                "creator": {
+                    "$ref": "#/definitions/Author"
+                },
+                "interpretedAsClaim": {
+                    "$ref": "#/definitions/InterpretedAsClaim"
+                },
+                "mediaItemAppearance": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MediaItemAppearance"
+                    }
+                }
+            },
+            "required": [
+                "@type",
+                "creator",
+                "interpretedAsClaim",
+                "mediaItemAppearance"
+            ],
+            "title": "ItemReviewed"
+        },
+        "InterpretedAsClaim": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "@type": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "@type",
+                "description"
+            ],
+            "title": "InterpretedAsClaim"
+        },
+        "MediaItemAppearance": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "@type": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "contentUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ]
+                },
+                "archivedAt": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ]
+                }
+            },
+            "required": [
+                "@type"
+            ],
+            "title": "MediaItemAppearance"
+        }
+    }
+}

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -2,8 +2,4 @@
 require "test_helper"
 
 class ApplicationControllerTest < ActionDispatch::IntegrationTest
-  test "can properly determine model for url" do
-    assert_equal Sources::InstagramPost, ApplicationController.new().model_for_url("https://www.instagram.com/p/CBcqOkyDDH8/?utm_source=ig_embed")
-    assert_equal Sources::Tweet, ApplicationController.new().model_for_url("https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
-  end
 end

--- a/test/controllers/archive_controller_test.rb
+++ b/test/controllers/archive_controller_test.rb
@@ -6,4 +6,10 @@ class ArchiveControllerTest < ActionDispatch::IntegrationTest
     get root_url
     assert_response :success
   end
+  test "load correct model for url" do
+    model_for_twitter_url = ArchiveItem.model_for_url("https://twitter.com/EFF/status/1427321758311387136")
+    model_for_instagram_url = ArchiveItem.model_for_url("https://www.instagram.com/p/CSjrCgrrZq4/")
+    assert_equal model_for_twitter_url, Sources::Tweet
+    assert_equal model_for_instagram_url, Sources::InstagramPost
+  end
 end

--- a/test/controllers/image_search_controller_test.rb
+++ b/test/controllers/image_search_controller_test.rb
@@ -1,3 +1,5 @@
+# typed: ignore
+
 require "test_helper"
 
 class ImageSearchControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/ingest_controller_test.rb
+++ b/test/controllers/ingest_controller_test.rb
@@ -8,8 +8,13 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
     assert_response 401
   end
 
+  test "Submitting an API request with a wrong key will return 401 error" do
+    post ingest_api_path, params: { media_review_json: { title: "Ahoy!" }.to_json, api_key: "wrong password" }, as: :json
+    assert_response 401
+  end
+
   test "Submitting real JSON but with a bad schemas to the ingest API gives a 400" do
-    post ingest_api_path, params: { media_review_json: { title: "Ahoy!" }.to_json }, as: :json
+    post ingest_api_path, params: { media_review_json: { title: "Ahoy!" }.to_json, api_key: "123456789" }, as: :json
     assert_response 400
 
     json = nil
@@ -27,7 +32,7 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "Submitting invalid JSON to the ingest API gives a 400" do
-    post ingest_api_path, params: { media_review_json: { title: "Ahoy!" } }, as: :json
+    post ingest_api_path, params: { media_review_json: { title: "Ahoy!" }, api_key: "123456789" }, as: :json
     assert_response 400
 
     json = nil
@@ -82,7 +87,7 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
       }
     }.to_json
 
-    post ingest_api_path, params: { media_review_json: media_review_json }, as: :json
+    post ingest_api_path, params: { media_review_json: media_review_json, api_key: "123456789" }, as: :json
     assert_response 200
 
     json = nil

--- a/test/controllers/ingest_controller_test.rb
+++ b/test/controllers/ingest_controller_test.rb
@@ -1,0 +1,100 @@
+# typed: ignore
+
+require "test_helper"
+
+class IngestControllerTest < ActionDispatch::IntegrationTest
+  test "Submitting real JSON but with a bad schemas to the ingest API gives a 400" do
+    post ingest_api_path, params: { media_review_json: { title: "Ahoy!" }.to_json }, as: :json
+    assert_response 400
+
+    json = nil
+    assert_nothing_raised do
+      json = JSON.parse(response.body)
+    end
+
+    assert_includes json.keys, "error_code"
+    assert_includes json.keys, "error"
+    assert_includes json.keys, "information"
+
+    assert_equal 11, json["error_code"]
+    assert_equal "Error parsing JSON, JSON does not conform to schema", json["error"]
+    # TODO: add information
+  end
+
+  test "Submitting invalid JSON to the ingest API gives a 400" do
+    post ingest_api_path, params: { media_review_json: { title: "Ahoy!" } }, as: :json
+    assert_response 400
+
+    json = nil
+    assert_nothing_raised do
+      json = JSON.parse(response.body)
+    end
+
+    assert_includes json.keys, "error_code"
+    assert_includes json.keys, "error"
+    assert_includes json.keys, "information"
+
+    assert_equal 10, json["error_code"]
+    assert_equal "Error parsing JSON, invalid JSON", json["error"]
+    # TODO: add information
+  end
+
+  test "Can archive media review from json" do
+    media_review_json = {
+      "@context": "https://schema.org",
+      "@type": " MediaReview",
+      "datePublished": "2021-04-27",
+      "url": "https://www.politifact.com/factchecks/2021/apr/27/instagram-posts/mariah-carey-didnt-fake-getting-her-covid-19-vacci/",
+      "author": {
+        "@type": "Organization",
+        "name": "PolitiFact",
+        "url": "https://politifact.com"
+      },
+      "mediaAuthenticityCategory": "DecontexualizedContent",
+      "originalMediaContextDescription": "Singer Mariah Carey shared a video of herself receiving a COVID-19 vaccination.",
+      "itemReviewed": {
+        "@type": "MediaReviewItem",
+        "creator": {
+          "@type": "Person",
+          "name": "Instagram user",
+          "url": "https://www.instagram.com/wrong_saloon_bear/?hl=en"
+        },
+        "interpretedAsClaim": {
+          "@type": "Claim",
+          "description": "Mariah Carey faked getting her COVID-19 vaccine because the needle can’t be seen coming out of her arm."
+        },
+        "mediaItemAppearance": [
+          {
+            "@type": "VideoObjectSnapshot",
+            "description": "An Instagram user posted a zoomed-in version of a video of Mariah Carey receiving a COVID vaccination, writing ‘It’s all a scam, don’t celebrate celebrities.’"
+          },
+          {
+            "@type": "VideoObjectSnapshot",
+            "contentUrl": "https://www.instagram.com/p/CNtao_WA0Dr/",
+            "archivedAt": "https://archive.is/EXAMPLE"
+          }
+        ]
+      }
+    }.to_json
+
+    post ingest_api_path, params: { media_review_json: media_review_json }, as: :json
+    assert_response 200
+
+    json = nil
+    assert_nothing_raised do
+      json = JSON.parse(response.body)
+    end
+
+    assert_includes json.keys, "response_code"
+    assert_includes json.keys, "response"
+    assert_includes json.keys, "media_object_id"
+
+    assert_equal 20, json["response_code"]
+    assert_equal "Successfully archived media object", json["response"]
+    assert_not_empty json["media_object_id"]
+
+    post = ArchiveItem.find(json["media_object_id"])
+    assert_not_nil post
+    assert_not_empty post.media_review
+  end
+end

--- a/test/controllers/ingest_controller_test.rb
+++ b/test/controllers/ingest_controller_test.rb
@@ -3,6 +3,11 @@
 require "test_helper"
 
 class IngestControllerTest < ActionDispatch::IntegrationTest
+  test "Submitting an API request without a key will return 401 error" do
+    post ingest_api_path, params: { media_review_json: { title: "Ahoy!" }.to_json }, as: :json
+    assert_response 401
+  end
+
   test "Submitting real JSON but with a bad schemas to the ingest API gives a 400" do
     post ingest_api_path, params: { media_review_json: { title: "Ahoy!" }.to_json }, as: :json
     assert_response 400

--- a/test/fixtures/api_keys.yml
+++ b/test/fixtures/api_keys.yml
@@ -4,12 +4,8 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-# one: {}
+one: {}
 # column: value
 #
-# two: {}
+two: {}
 # column: value
-
-user1:
-  email: "test123@example.com"
-  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>

--- a/test/fixtures/api_keys.yml
+++ b/test/fixtures/api_keys.yml
@@ -4,8 +4,6 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
-# column: value
-#
-two: {}
-# column: value
+one:
+  hashed_api_key: <%= ZenoEncryption.hash_string("123456789") %>
+  user: user1

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -13,3 +13,5 @@
 user1:
   email: "test123@example.com"
   encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
+  approved: true
+  confirmed_at: <%= Time.now %>

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class ApiKeyTest < ActiveSupport::TestCase
+  test "creating an api key returns the clear string of the key" do
+    api_key = ApiKey.create(user: users(:user1))
+    assert_not_nil api_key.api_key
+    assert_not_nil api_key.hashed_api_key
+  end
+
+  test "retrieving an api key does not return the clear string of the key" do
+    api_key = ApiKey.create(user: users(:user1))
+    api_key = ApiKey.find(api_key.id)
+    assert_nil api_key.api_key
+    assert_not_nil api_key.hashed_api_key
+  end
+
+  test "deleting a user deletes all of its api keys" do
+    user = users(:user1)
+    api_key = ApiKey.create(user: user)
+    assert_not_nil api_key
+    user.destroy!
+    assert_raise(ActiveRecord::RecordNotFound) do
+      ApiKey.find(api_key.id)
+    end
+  end
+end

--- a/test/models/archive_entity_test.rb
+++ b/test/models/archive_entity_test.rb
@@ -2,7 +2,4 @@
 require "test_helper"
 
 class ArchiveEntityTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#71 
This PR sets up basic user authentication for Zenodotus. It uses Devise to create a User model, allowing visitors to create accounts and log in to the app. In fact, as currently setup, it forces user to log in -- attempts to access any controller without logging in will fail + reroute to the login page. 

It uses a boolean flag to mark User accounts as admins. For now, admins have the special privileges of viewing their API key ( which can be used to authenticate remote requests) and approving/denying signup requests. 