### PR TITLE
Switch from using Zorki locally to external host

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -137,7 +137,7 @@ gem "streamio-ffmpeg"
 # gem "zorki", "0.1.0", path: "~/Repositories/zorki" # instagram
 # gem "birdsong", "0.1.0", path: "~/Repositories/birdsong" # twitter
 
-gem "zorki", "0.1.0", git: "https://github.com/cguess/zorki"
+# gem "zorki", "0.1.0", git: "https://github.com/cguess/zorki"
 gem "birdsong", "0.1.0", git: "https://github.com/cguess/birdsong"
 
 # A progress bar for our Rake tasks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,17 +13,6 @@ GIT
       oauth (~> 0.5.6)
       typhoeus (~> 1.4.0)
 
-GIT
-  remote: https://github.com/cguess/zorki
-  revision: b6aac3c508905aa200fbef1c96c3c4b8b6221e68
-  specs:
-    zorki (0.1.0)
-      apparition
-      capybara
-      oj
-      selenium-webdriver
-      typhoeus
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -88,9 +77,6 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    apparition (0.6.0)
-      capybara (~> 3.13, < 4)
-      websocket-driver (>= 0.6.5)
     ast (2.4.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
@@ -183,7 +169,6 @@ GEM
     nokogiri (1.12.3-x86_64-darwin)
       racc (~> 1.4)
     oauth (0.5.6)
-    oj (3.13.2)
     orm_adapter (0.5.0)
     os (1.1.1)
     parallel (1.20.1)
@@ -463,7 +448,6 @@ DEPENDENCIES
   webdrivers
   webpacker (~> 5.0)
   yard
-  zorki (= 0.1.0)!
 
 RUBY VERSION
    ruby 3.0.2p107

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -3,3 +3,7 @@ Figaro.require_keys("TWITTER_BEARER_TOKEN", "INSTAGRAM_USER_NAME", "INSTAGRAM_PA
 # This is the salt value used to encrypt various things, you can generate one by running
 # `rails secret`
 Figaro.require_keys("KEY_ENCRYPTION_SALT")
+
+# The URL and auth key for the external Zorki gem scraper
+Figaro.require_keys("ZORKI_SERVER_URL")
+Figaro.require_keys("ZORKI_AUTH_KEY")

--- a/test/models/instagram_post_test.rb
+++ b/test/models/instagram_post_test.rb
@@ -16,10 +16,10 @@ class InstagramPostTest < ActiveSupport::TestCase
     assert_not_nil archive_item
     assert_kind_of ArchiveItem, archive_item
 
-    assert_equal @zorki_post.first.text, archive_item.instagram_post.text
-    assert_equal @zorki_post.first.id, archive_item.instagram_post.instagram_id
-    assert_equal @zorki_post.first.id, archive_item.service_id
-    assert_equal @zorki_post.first.date, archive_item.instagram_post.posted_at
+    assert_equal @zorki_post.first["text"], archive_item.instagram_post.text
+    assert_equal @zorki_post.first["id"], archive_item.instagram_post.instagram_id
+    assert_equal @zorki_post.first["id"], archive_item.service_id
+    assert_equal @zorki_post.first["date"], archive_item.instagram_post.posted_at.strftime("%FT%T%:z")
 
     assert_not_nil archive_item.instagram_post.author
     assert_not_nil archive_item.instagram_post.images


### PR DESCRIPTION
Due to the fact that Instagram (and probably everyone else) blocks AWS,
Azure, etc. IP addresses we need to run the scraping from somewhere
else. To that end I created a server for it and am running it locally in
my apartment off a Raspberry Pi 3. So this changes the behaviour to call
the server instead of the local version of the gem.

This adds two new required environment variables:
`ZORKI_SERVER_URL` which points to the right server
`ZORKI_AUTH_KEY` which is the auth key for authenticating the requests

Everything else stays exactly the same.

To test:
1. Pull this branch
2. Run `bundle install` since the zorki gem is now removed from the
   requirements
3. Add the two environment variable however you're handling that
4. Run `rails t` and it'll pass