### PR TITLE
Add mediareview model, relations, and db table

### DIFF
--- a/app/models/archive_item.rb
+++ b/app/models/archive_item.rb
@@ -6,6 +6,8 @@ class ArchiveItem < ApplicationRecord
   delegate :images, to: :archivable_item
   delegate :videos, to: :archivable_item
 
+  has_one :media_review
+
   # Creates an +ArchiveEntity
   #
   # @!scope class

--- a/app/models/archive_item.rb
+++ b/app/models/archive_item.rb
@@ -6,7 +6,7 @@ class ArchiveItem < ApplicationRecord
   delegate :images, to: :archivable_item
   delegate :videos, to: :archivable_item
 
-  has_one :media_review
+  has_one :media_review, dependent: :destroy
 
   # Creates an +ArchiveEntity
   #

--- a/app/models/media_review.rb
+++ b/app/models/media_review.rb
@@ -1,0 +1,8 @@
+# typed: false
+
+class MediaReview < ApplicationRecord
+
+  belongs_to :archive_item, optional: false, class_name: "ArchiveItem"
+
+end
+

--- a/app/models/media_review.rb
+++ b/app/models/media_review.rb
@@ -1,8 +1,3 @@
-# typed: false
-
 class MediaReview < ApplicationRecord
-
   belongs_to :archive_item, optional: false, class_name: "ArchiveItem"
-
 end
-

--- a/db/migrate/20210913200056_create_media_review.rb
+++ b/db/migrate/20210913200056_create_media_review.rb
@@ -2,9 +2,9 @@ class CreateMediaReview < ActiveRecord::Migration[6.1]
   def change
     create_table :media_review, id: :uuid do |t|
       t.timestamps
-      t.text :link, null: false
-      t.text :authenticity, null: false
-      t.text :context, null: false
+      t.text :original_media_link, null: false
+      t.text :media_authenticity_category, null: false
+      t.text :original_media_context_description, null: false
       t.belongs_to :archive_item, type: :uuid, foreign_key: true
       # has_one claimreview?
     end

--- a/db/migrate/20210913200056_create_media_review.rb
+++ b/db/migrate/20210913200056_create_media_review.rb
@@ -1,0 +1,12 @@
+class CreateMediaReview < ActiveRecord::Migration[6.1]
+  def change
+    create_table :media_review, id: :uuid do |t|
+      t.timestamps
+      t.text :media_link, null: false
+      t.text :media_authenticity, null: false
+      t.text :media_context, null: false
+      t.belongs_to :archive_item, type: :uuid, foreign_key: true
+      # has_one claimreview?
+    end
+  end
+end

--- a/db/migrate/20210913200056_create_media_review.rb
+++ b/db/migrate/20210913200056_create_media_review.rb
@@ -2,9 +2,9 @@ class CreateMediaReview < ActiveRecord::Migration[6.1]
   def change
     create_table :media_review, id: :uuid do |t|
       t.timestamps
-      t.text :media_link, null: false
-      t.text :media_authenticity, null: false
-      t.text :media_context, null: false
+      t.text :link, null: false
+      t.text :authenticity, null: false
+      t.text :context, null: false
       t.belongs_to :archive_item, type: :uuid, foreign_key: true
       # has_one claimreview?
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2021_08_17_163159) do
-
+ActiveRecord::Schema.define(version: 2021_09_13_200056) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -93,6 +91,16 @@ ActiveRecord::Schema.define(version: 2021_08_17_163159) do
     t.index ["instagram_post_id"], name: "index_instagram_videos_on_instagram_post_id"
   end
 
+  create_table "media_review", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.text "media_link", null: false
+    t.text "media_authenticity", null: false
+    t.text "media_context", null: false
+    t.uuid "archive_item_id"
+    t.index ["archive_item_id"], name: "index_media_review_on_archive_item_id"
+  end
+
   create_table "text_searches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "query"
     t.string "user_id"
@@ -164,6 +172,7 @@ ActiveRecord::Schema.define(version: 2021_08_17_163159) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "approved", default: false, null: false
     t.boolean "admin", default: false, null: false
+    t.boolean "restricted", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
@@ -173,6 +182,7 @@ ActiveRecord::Schema.define(version: 2021_08_17_163159) do
   add_foreign_key "api_keys", "users"
   add_foreign_key "instagram_images", "instagram_posts"
   add_foreign_key "instagram_videos", "instagram_posts"
+  add_foreign_key "media_review", "archive_items"
   add_foreign_key "twitter_images", "tweets"
   add_foreign_key "twitter_videos", "tweets"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -94,9 +94,9 @@ ActiveRecord::Schema.define(version: 2021_09_13_200056) do
   create_table "media_review", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.text "media_link", null: false
-    t.text "media_authenticity", null: false
-    t.text "media_context", null: false
+    t.text "link", null: false
+    t.text "authenticity", null: false
+    t.text "context", null: false
     t.uuid "archive_item_id"
     t.index ["archive_item_id"], name: "index_media_review_on_archive_item_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -91,16 +91,6 @@ ActiveRecord::Schema.define(version: 2021_09_13_200056) do
     t.index ["instagram_post_id"], name: "index_instagram_videos_on_instagram_post_id"
   end
 
-  create_table "media_review", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.text "link", null: false
-    t.text "authenticity", null: false
-    t.text "context", null: false
-    t.uuid "archive_item_id"
-    t.index ["archive_item_id"], name: "index_media_review_on_archive_item_id"
-  end
-
   create_table "text_searches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "query"
     t.string "user_id"
@@ -172,6 +162,7 @@ ActiveRecord::Schema.define(version: 2021_09_13_200056) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "approved", default: false, null: false
     t.boolean "admin", default: false, null: false
+    t.boolean "restricted", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
@@ -181,7 +172,6 @@ ActiveRecord::Schema.define(version: 2021_09_13_200056) do
   add_foreign_key "api_keys", "users"
   add_foreign_key "instagram_images", "instagram_posts"
   add_foreign_key "instagram_videos", "instagram_posts"
-  add_foreign_key "media_review", "archive_items"
   add_foreign_key "twitter_images", "tweets"
   add_foreign_key "twitter_videos", "tweets"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -172,7 +172,6 @@ ActiveRecord::Schema.define(version: 2021_09_13_200056) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "approved", default: false, null: false
     t.boolean "admin", default: false, null: false
-    t.boolean "restricted", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
This PR adds a basic `MediaReview` model with a few attributes. A `MediaReview` belongs to an `ArchiveItem`, and will eventually be created in the IngestController here: 

https://github.com/TechAndCheck/zenodotus/blob/8d405d89299146dc06c1b9d20a81a1e26e7ada13/app/models/archive_item.rb#L16-L31