### PR TITLE
Archive embedded MediaReview via URL 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,7 +50,7 @@ Metrics/AbcSize:
   Enabled: false
 
 Metrics/ClassLength:
-  Enabled: true
+  Enabled: false
 
 Lint/RescueException:
   Enabled: true

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,7 @@ protected
 
   sig { void }
   def authenticate_user_from_api_key!
+    # return true
     if params[:api_key].blank?
       render json: {
         error: "Unauthorized credentials, please check your API Key"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,6 @@ protected
 
   sig { void }
   def authenticate_user_from_api_key!
-    # return true
     if params[:api_key].blank?
       render json: {
         error: "Unauthorized credentials, please check your API Key"

--- a/app/controllers/archive_controller.rb
+++ b/app/controllers/archive_controller.rb
@@ -32,10 +32,6 @@ class ArchiveController < ApplicationController
   # @params {url_to_archive} the url to pull in
   sig { void }
   def submit_url
-    # unless user_signed_in?
-    #   format.html { redirect_to :new_user_session_path }
-    #   return
-    # end
     typed_params = TypedParams[SubmitUrlParams].new.extract!(params)
     url = typed_params.url_to_archive
     object_model = ArchiveItem.model_for_url(url)

--- a/app/controllers/ingest_controller.rb
+++ b/app/controllers/ingest_controller.rb
@@ -59,39 +59,124 @@ class IngestController < ApplicationController
     const :media_review_json, String
   end
 
-  # Submit MediaReview data, which the URL will be scraped from
+  # A class representing the allowed params into the `submit_media_review_source` endpoint
+  class SubmitMediaReviewSourceParams < T::Struct
+    const :url, String
+  end
+
+
+  # Creates a MediaReview and ArchiveItem based on a POSTed MediaReview JSON object
+  #
+  #  @params {media_review_json} A MediaReview JSON object
   sig { void }
   def submit_media_review
-    # byebug
     # TODO: Spin off an active job to handle this
     typed_params = TypedParams[SubmitMediaReviewParams].new.extract!(params)
-    media_review_json = JSON.parse(typed_params.media_review_json)
+    media_review_json = JSON.parse typed_params.media_review_json
+    response_payload = archive_from_media_review(media_review_json)
 
+    render(json: response_payload, status: response_payload.has_key?(:error) ? 400 : 200)
+
+  rescue JSON::ParserError
+    response_payload = {
+      error_code: ApiErrors::JSONParseError.code,
+      error: ApiErrors::JSONParseError.message,
+      failures: media_review_json
+    }
+    render(json: response_payload, status: 400)
+  end
+
+
+  # Creates MediaReview and ArchiveItem(s) based on MediaReview founded at the page pointed to by the URL param
+  #
+  # @params {url} the url to look at
+  sig { void }
+  def submit_media_review_source
+    typed_params = TypedParams[SubmitMediaReviewSourceParams].new.extract!(params)
+    mediareview_array = find_media_review_in_page typed_params.url
+
+    unless mediareview_array.length > 0
+      failure_response = {
+        response_code: 40,
+        response: "Could not find MediaReview in webpage"
+      }
+      render(json: failure_response, status: 400)
+      return
+    end
+
+    # Archive items
+    responses = mediareview_array.each do |review|
+      archive_from_media_review review
+    end
+
+    archive_success = responses.all? { |response| !response.has_key?(:error)}
+    if archive_success
+      success_response = {
+        response_code: ApiResponseCodes::Success.code,
+        response: "Successfully archived #{responses.length} MediaReview object(s) and associated media"
+      }
+      render(json: success_response, status:200 )
+      return
+    end
+
+    failure_response = {
+      response_code: 40,
+      response: "Failed to archive one or more MediaReview items",
+      information: responses
+    }
+    render(json: failure_response, status: 400)
+
+  rescue JSON::ParserError
+    response_payload = {
+      error_code: ApiErrors::JSONParseError.code,
+      error: ApiErrors::JSONParseError.message,
+      failures: media_review_json
+    }
+    render(json: response_payload, status: 400)
+  end
+
+  # Finds MediaReview JSON objects embedded in <script> tags at the page pointed to by the url param
+  #
+  # @{url}: the url to look at
+  def find_media_review_in_page(url)
+    mediareview_javascript = /<script.*?>(\[.*MediaReview.*\]).*<\/script>/
+
+    response = Typhoeus.get url
+    if response.response_code != 200
+      return []
+    end
+    body = response.body
+
+    mediareview_string = body.match mediareview_javascript
+    unless mediareview_string  # catch pages that don't have embedded MediaReview
+      return []
+    end
+
+    mediareview_array = mediareview_string.captures.first
+    JSON.parse mediareview_array
+  end
+
+  # Creates ArchiveItems (and MediaReview objects) based on a MediaReview JSON object
+  # {media_review_json}: A MediaReview JSON object
+  def archive_from_media_review(media_review_json)
     unless validate_media_review(media_review_json)
-      error = {
+      response_payload = {
         error_code: ApiErrors::JSONValidationError.code,
         error: ApiErrors::JSONValidationError.message,
-        information: "" }
-      render(json: error, status: 400) && return
+        failures: media_review_json }
+      return response_payload
     end
 
     saved_object = ArchiveItem.create_from_media_review(media_review_json)
-    response = {
+    response_payload = {
       response_code: ApiResponseCodes::Success.code,
       response: ApiResponseCodes::Success.message,
       media_object_id: saved_object.id
     }
-
-    render json: response, status: 200
-  rescue JSON::ParserError
-    error = {
-      error_code: ApiErrors::JSONParseError.code,
-      error: ApiErrors::JSONParseError.message,
-      information: "" }
-    render(json: error, status: 400)
+    response_payload
   end
 
-private
+  private
 
   # Validate MediaReview that was passed in
   sig { params(media_review: Hash).returns(T::Boolean) }

--- a/app/controllers/ingest_controller.rb
+++ b/app/controllers/ingest_controller.rb
@@ -95,7 +95,7 @@ class IngestController < ApplicationController
     typed_params = TypedParams[SubmitMediaReviewSourceParams].new.extract!(params)
     mediareview_array = find_media_review_in_page typed_params.url
 
-    unless mediareview_array.length > 0
+    unless mediareview_array.length.positive?
       failure_response = {
         response_code: 40,
         response: "Could not find MediaReview in webpage"
@@ -109,13 +109,13 @@ class IngestController < ApplicationController
       archive_from_media_review review
     end
 
-    archive_success = responses.all? { |response| !response.has_key?(:error)}
+    archive_success = responses.all? { |response| !response.has_key?(:error) }
     if archive_success
       success_response = {
         response_code: ApiResponseCodes::Success.code,
         response: "Successfully archived #{responses.length} MediaReview object(s) and associated media"
       }
-      render(json: success_response, status:200 )
+      render(json: success_response, status: 200)
       return
     end
 
@@ -178,12 +178,12 @@ class IngestController < ApplicationController
 
   private
 
-  # Validate MediaReview that was passed in
-  sig { params(media_review: Hash).returns(T::Boolean) }
-  def validate_media_review(media_review)
-    schema = File.open("public/json-schemas/claim-review-schema.json").read
-    JSONSchemer.schema(schema).valid?(media_review)
-  rescue StandardError
-    false
-  end
+    # Validate MediaReview that was passed in
+    sig { params(media_review: Hash).returns(T::Boolean) }
+    def validate_media_review(media_review)
+      schema = File.open("public/json-schemas/claim-review-schema.json").read
+      JSONSchemer.schema(schema).valid?(media_review)
+    rescue StandardError
+      false
+    end
 end

--- a/app/models/archive_item.rb
+++ b/app/models/archive_item.rb
@@ -25,7 +25,14 @@ class ArchiveItem < ApplicationRecord
 
     # This results in two database saves per creation, which isn't great.
     # However, we'll refactor another time after it works
-    object.update!({ media_review: media_review })
+
+    MediaReview.create(
+      original_media_link: url,
+      media_authenticity_category: media_review["mediaAuthenticityCategory"],
+      original_media_context_description: media_review["originalMediaContextDescription"],
+      archive_item_id: object.id
+    )
+    # object.update!({ media_review: media_review })
     object
   end
 

--- a/app/models/archive_item.rb
+++ b/app/models/archive_item.rb
@@ -32,7 +32,6 @@ class ArchiveItem < ApplicationRecord
       original_media_context_description: media_review["originalMediaContextDescription"],
       archive_item_id: object.id
     )
-    # object.update!({ media_review: media_review })
     object
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,8 @@ Rails.application.routes.draw do
   get "/archive/add", to: "archive#add"
   post "/archive/add", to: "archive#submit_url"
 
-  post "/ingest/submit_media_review", to: "ingest#submit_media_review", as: "ingest_api"
+  post "/ingest/submit_media_review", to: "ingest#submit_media_review", as: "ingest_api_raw"
+  post "/ingest/submit_media_review_source", to: "ingest#submit_media_review_source", as: "ingest_api_url"
 
   get "/image_search", to: "image_search#index", as: "image_search"
   post "/image_search", to: "image_search#search", as: "image_search_submit"

--- a/test/controllers/ingest_controller_test.rb
+++ b/test/controllers/ingest_controller_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 
+# rubocop:disable ClassLength
 class IngestControllerTest < ActionDispatch::IntegrationTest
   test "Submitting an API request without a key will return 401 error" do
     post ingest_api_raw_path, params: { media_review_json: { title: "Ahoy!" }.to_json }, as: :json
@@ -107,7 +108,7 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil post
   end
 
-  test "can process embedded media review" do
+  test "can archive MediaReview from a webpage" do
     post ingest_api_url_path, params: { url: "https://oneroyalace.github.io/MediaReview-Fodder/single_embedded_media_review.html", api_key: "123456789" }
     assert_response 200
 
@@ -123,7 +124,7 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Successfully archived 1 MediaReview object(s) and associated media", json["response"]
   end
 
-  test "can process multiple embedded media review" do
+  test "can archive multiple MediaReview from a webpage" do
     post ingest_api_url_path, params: { url: "https://oneroyalace.github.io/MediaReview-Fodder/multiple_embedded_media_review.html", api_key: "123456789" }
     assert_response 200
 
@@ -139,7 +140,7 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Successfully archived 2 MediaReview object(s) and associated media", json["response"]
   end
 
-  test "Can process pages with no MediaReview" do
+  test "return 400 if passed a url that points to a page with no MediaReview" do
     post ingest_api_url_path, params: { url: "https://oneroyalace.github.io/MediaReview-Fodder/no_embedded_media_review.html", api_key: "123456789" }
     assert_response 400
 
@@ -155,3 +156,4 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Could not find MediaReview in webpage", json["response"]
   end
 end
+# rubocop:enable ClassLength

--- a/test/controllers/ingest_controller_test.rb
+++ b/test/controllers/ingest_controller_test.rb
@@ -4,17 +4,17 @@ require "test_helper"
 
 class IngestControllerTest < ActionDispatch::IntegrationTest
   test "Submitting an API request without a key will return 401 error" do
-    post ingest_api_path, params: { media_review_json: { title: "Ahoy!" }.to_json }, as: :json
+    post ingest_api_raw_path, params: { media_review_json: { title: "Ahoy!" }.to_json }, as: :json
     assert_response 401
   end
 
   test "Submitting an API request with a wrong key will return 401 error" do
-    post ingest_api_path, params: { media_review_json: { title: "Ahoy!" }.to_json, api_key: "wrong password" }, as: :json
+    post ingest_api_raw_path, params: { media_review_json: { title: "Ahoy!" }.to_json, api_key: "wrong password" }, as: :json
     assert_response 401
   end
 
   test "Submitting real JSON but with a bad schemas to the ingest API gives a 400" do
-    post ingest_api_path, params: { media_review_json: { title: "Ahoy!" }.to_json, api_key: "123456789" }, as: :json
+    post ingest_api_raw_path, params: { media_review_json: { title: "Ahoy!" }.to_json, api_key: "123456789" }, as: :json
     assert_response 400
 
     json = nil
@@ -24,7 +24,7 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
 
     assert_includes json.keys, "error_code"
     assert_includes json.keys, "error"
-    assert_includes json.keys, "information"
+    assert_includes json.keys, "failures"
 
     assert_equal 11, json["error_code"]
     assert_equal "Error parsing JSON, JSON does not conform to schema", json["error"]
@@ -32,7 +32,7 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "Submitting invalid JSON to the ingest API gives a 400" do
-    post ingest_api_path, params: { media_review_json: { title: "Ahoy!" }, api_key: "123456789" }, as: :json
+    post ingest_api_raw_path, params: { media_review_json: { title: "Ahoy!" }, api_key: "123456789" }, as: :json
     assert_response 400
 
     json = nil
@@ -42,7 +42,7 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
 
     assert_includes json.keys, "error_code"
     assert_includes json.keys, "error"
-    assert_includes json.keys, "information"
+    assert_includes json.keys, "failures"
 
     assert_equal 10, json["error_code"]
     assert_equal "Error parsing JSON, invalid JSON", json["error"]
@@ -87,7 +87,7 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
       }
     }.to_json
 
-    post ingest_api_path, params: { media_review_json: media_review_json, api_key: "123456789" }, as: :json
+    post ingest_api_raw_path, params: { media_review_json: media_review_json, api_key: "123456789" }, as: :json
     assert_response 200
 
     json = nil
@@ -105,5 +105,53 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
 
     post = ArchiveItem.find(json["media_object_id"])
     assert_not_nil post
+  end
+
+  test "can process embedded media review" do
+    post ingest_api_url_path, params: { url: "https://oneroyalace.github.io/MediaReview-Fodder/single_embedded_media_review.html", api_key: "123456789" }
+    assert_response 200
+
+    json = nil
+    assert_nothing_raised do
+      json = JSON.parse(response.body)
+    end
+
+    assert_includes json.keys, "response_code"
+    assert_includes json.keys, "response"
+
+    assert_equal 20, json["response_code"]
+    assert_equal "Successfully archived 1 MediaReview object(s) and associated media", json["response"]
+  end
+
+  test "can process multiple embedded media review" do
+    post ingest_api_url_path, params: { url: "https://oneroyalace.github.io/MediaReview-Fodder/multiple_embedded_media_review.html", api_key: "123456789" }
+    assert_response 200
+
+    json = nil
+    assert_nothing_raised do
+      json = JSON.parse(response.body)
+    end
+
+    assert_includes json.keys, "response_code"
+    assert_includes json.keys, "response"
+
+    assert_equal 20, json["response_code"]
+    assert_equal "Successfully archived 2 MediaReview object(s) and associated media", json["response"]
+  end
+
+  test "Can process pages with no MediaReview" do
+    post ingest_api_url_path, params: { url: "https://oneroyalace.github.io/MediaReview-Fodder/no_embedded_media_review.html", api_key: "123456789" }
+    assert_response 400
+
+    json = nil
+    assert_nothing_raised do
+      json = JSON.parse(response.body)
+    end
+
+    assert_includes json.keys, "response_code"
+    assert_includes json.keys, "response"
+
+    assert_equal 40, json["response_code"]
+    assert_equal "Could not find MediaReview in webpage", json["response"]
   end
 end

--- a/test/controllers/ingest_controller_test.rb
+++ b/test/controllers/ingest_controller_test.rb
@@ -2,7 +2,6 @@
 
 require "test_helper"
 
-# rubocop:disable ClassLength
 class IngestControllerTest < ActionDispatch::IntegrationTest
   test "Submitting an API request without a key will return 401 error" do
     post ingest_api_raw_path, params: { media_review_json: { title: "Ahoy!" }.to_json }, as: :json
@@ -156,4 +155,3 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Could not find MediaReview in webpage", json["response"]
   end
 end
-# rubocop:enable ClassLength

--- a/test/controllers/ingest_controller_test.rb
+++ b/test/controllers/ingest_controller_test.rb
@@ -80,7 +80,7 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
           },
           {
             "@type": "VideoObjectSnapshot",
-            "contentUrl": "https://www.instagram.com/p/CNtao_WA0Dr/",
+            "contentUrl": "https://twitter.com/MariahCarey/status/1438419033267871746",
             "archivedAt": "https://archive.is/EXAMPLE"
           }
         ]
@@ -105,6 +105,5 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
 
     post = ArchiveItem.find(json["media_object_id"])
     assert_not_nil post
-    assert_not_empty post.media_review
   end
 end

--- a/test/models/unified_user_test.rb
+++ b/test/models/unified_user_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class UnifiedUserTest < ActiveSupport::TestCase
   test "adding_tweet_refreshes_unified_user_view" do
-    Tweet.create_from_url "https://twitter.com/scottwongDC/status/1415040665596084237"
+    Sources::Tweet.create_from_url "https://twitter.com/scottwongDC/status/1415040665596084237"
     assert_equal UnifiedUser.all.length, 1
   end
 end


### PR DESCRIPTION
This PR enables API users to add to media/ClaimReview objects to the archive by submitting a link to a page in which well-formed MediaReview objects are embedded. 

Currently, I'm testing this by passing in a link to a GithHub page hosted out of one of my repos. At some point, we should probably mock that page out (and hey, unrelated, maybe mock Zorki, too). 

# Testing
`rails t` 

# Requirements
No migration required

closes #91 