### PR TITLE
Add MediaReview models

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,23 @@
 # typed: strict
 module ApplicationHelper
+
+  # A helper function that makes Schema.org objects postgres-friendly
+  def self.clean_schema_org_hash(h)
+    h.transform_keys do |key|
+      if key == "@type"
+        "_type"
+      elsif key.downcase != key
+        self.convert_from_camel_case(key)
+      else
+        key
+      end
+    end
+  end
+
+  # A helper function that returns an underscored version of a camelCase string
+  def self.convert_from_camel_case(str)
+    underscored_str = ""
+    str.each_char { |ch| underscored_str << (ch.upcase == ch ? "_" + ch.downcase : ch ) }
+    underscored_str
+  end
 end

--- a/app/models/media_review.rb
+++ b/app/models/media_review.rb
@@ -1,5 +1,0 @@
-class MediaReview < ApplicationRecord
-  belongs_to :archive_item, optional: false, class_name: "ArchiveItem"
-  # belongs_to :tweet, optional: true
-  # belongs_to :instagram_post, optional: true
-end

--- a/app/models/media_review_models/media_item_appearance.rb
+++ b/app/models/media_review_models/media_item_appearance.rb
@@ -1,0 +1,5 @@
+# typed: false
+
+class MediaReviewModels::MediaItemAppearance < ApplicationRecord
+  belongs_to :media_review_item, optional: false, class_name: "MediaReviewModels::MediaReviewItem"
+end

--- a/app/models/media_review_models/media_review.rb
+++ b/app/models/media_review_models/media_review.rb
@@ -1,0 +1,8 @@
+class MediaReviewModels::MediaReview < ApplicationRecord
+  belongs_to :archive_item, optional: false, class_name: "ArchiveItem"
+
+  has_one :media_review_item
+  has_one :media_review_author
+
+  accepts_nested_attributes_for :media_review_item, :media_review_author
+end

--- a/app/models/media_review_models/media_review.rb
+++ b/app/models/media_review_models/media_review.rb
@@ -1,8 +1,8 @@
 class MediaReviewModels::MediaReview < ApplicationRecord
   belongs_to :archive_item, optional: false, class_name: "ArchiveItem"
 
-  has_one :media_review_item
-  has_one :media_review_author
+  has_one :media_review_item, dependent: :destroy
+  has_one :media_review_author, dependent: :destroy
 
   accepts_nested_attributes_for :media_review_item, :media_review_author
 end

--- a/app/models/media_review_models/media_review_author.rb
+++ b/app/models/media_review_models/media_review_author.rb
@@ -1,0 +1,6 @@
+# typed: false
+
+class MediaReviewModels::MediaReviewAuthor < ApplicationRecord
+  belongs_to :media_review, optional: true, class_name: "MediaReviewModels::MediaReview"
+
+end

--- a/app/models/media_review_models/media_review_author.rb
+++ b/app/models/media_review_models/media_review_author.rb
@@ -1,6 +1,5 @@
 # typed: false
 
 class MediaReviewModels::MediaReviewAuthor < ApplicationRecord
-  belongs_to :media_review, optional: true, class_name: "MediaReviewModels::MediaReview"
-
+  belongs_to :media_review, optional: false, class_name: "MediaReviewModels::MediaReview"
 end

--- a/app/models/media_review_models/media_review_item.rb
+++ b/app/models/media_review_models/media_review_item.rb
@@ -1,11 +1,10 @@
 # typed: false
 
 class MediaReviewModels::MediaReviewItem < ApplicationRecord
-  belongs_to :media_review, optional: true, class_name: "MediaReviewModels::MediaReview"
+  belongs_to :media_review, optional: false, class_name: "MediaReviewModels::MediaReview"
 
-  has_one :media_review_item_author
-  has_many :media_item_appearance
+  has_one :media_review_item_author, dependent: :destroy
+  has_many :media_item_appearance, dependent: :destroy
 
   accepts_nested_attributes_for :media_review_item_author, :media_item_appearance
-
 end

--- a/app/models/media_review_models/media_review_item.rb
+++ b/app/models/media_review_models/media_review_item.rb
@@ -1,0 +1,11 @@
+# typed: false
+
+class MediaReviewModels::MediaReviewItem < ApplicationRecord
+  belongs_to :media_review, optional: true, class_name: "MediaReviewModels::MediaReview"
+
+  has_one :media_review_item_author
+  has_many :media_item_appearance
+
+  accepts_nested_attributes_for :media_review_item_author, :media_item_appearance
+
+end

--- a/app/models/media_review_models/media_review_item_author.rb
+++ b/app/models/media_review_models/media_review_item_author.rb
@@ -1,0 +1,6 @@
+# typed: false
+
+class MediaReviewModels::MediaReviewItemAuthor < ApplicationRecord
+  belongs_to :media_review_item, optional: false, class_name: "MediaReviewModels::MediaReviewItem"
+
+end

--- a/db/migrate/20210914145948_create_media_review.rb
+++ b/db/migrate/20210914145948_create_media_review.rb
@@ -5,10 +5,7 @@ class CreateMediaReview < ActiveRecord::Migration[6.1]
       t.text :original_media_link, null: false
       t.text :media_authenticity_category, null: false
       t.text :original_media_context_description, null: false
-      # t.belongs_to :tweet, type: :uuid, foreign_key: true
-      # t.belongs_to :instagram_post, type: :uuid, foreign_key: true
       t.belongs_to :archive_item, type: :uuid, primary_key: :archive_item_id, foreign_key: :id
-      # has_one claimreview?
     end
   end
 end

--- a/db/migrate/20210926200723_create_media_review_item.rb
+++ b/db/migrate/20210926200723_create_media_review_item.rb
@@ -1,6 +1,8 @@
 class CreateMediaReviewItem < ActiveRecord::Migration[6.1]
   def change
     create_table :media_review_items, id: :uuid do |t|
+      t.text :interpreted_as_claim
+      t.belongs_to :media_review, type: :uuid, primary_key: :media_review_id, foreign_key: :id
     end
   end
 end

--- a/db/migrate/20210926200723_create_media_review_item.rb
+++ b/db/migrate/20210926200723_create_media_review_item.rb
@@ -1,0 +1,6 @@
+class CreateMediaReviewItem < ActiveRecord::Migration[6.1]
+  def change
+    create_table :media_review_items, id: :uuid do |t|
+    end
+  end
+end

--- a/db/migrate/20210927195737_create_media_review_author.rb
+++ b/db/migrate/20210927195737_create_media_review_author.rb
@@ -1,0 +1,9 @@
+class CreateMediaReviewAuthor < ActiveRecord::Migration[6.1]
+  def change
+    create_table :media_review_authors, id: :uuid do |t|
+      t.text :type
+      t.text :name
+      t.text :url
+    end
+  end
+end

--- a/db/migrate/20210927195737_create_media_review_author.rb
+++ b/db/migrate/20210927195737_create_media_review_author.rb
@@ -1,9 +1,11 @@
 class CreateMediaReviewAuthor < ActiveRecord::Migration[6.1]
   def change
     create_table :media_review_authors, id: :uuid do |t|
-      t.text :type
+      t.text :_type
       t.text :name
       t.text :url
+
+      t.belongs_to :media_review, type: :uuid, primary_key: :media_review_id, foreign_key: :id
     end
   end
 end

--- a/db/migrate/20210927200203_create_media_item_appearance.rb
+++ b/db/migrate/20210927200203_create_media_item_appearance.rb
@@ -1,0 +1,12 @@
+class CreateMediaItemAppearance < ActiveRecord::Migration[6.1]
+  def change
+    create_table :media_item_appearances, id: :uuid do |t|
+      t.text :type
+      t.text :description
+      t.text :content_url
+      t.text :archived_at
+
+      t.belongs_to :media_review_item, type: :uuid, primary_key: :media_review_item_id, foreign_key: :id
+    end
+  end
+end

--- a/db/migrate/20210927200203_create_media_item_appearance.rb
+++ b/db/migrate/20210927200203_create_media_item_appearance.rb
@@ -1,7 +1,7 @@
 class CreateMediaItemAppearance < ActiveRecord::Migration[6.1]
   def change
     create_table :media_item_appearances, id: :uuid do |t|
-      t.text :type
+      t.text :_type
       t.text :description
       t.text :content_url
       t.text :archived_at

--- a/db/migrate/20210927200524_create_media_review_item_author.rb
+++ b/db/migrate/20210927200524_create_media_review_item_author.rb
@@ -1,7 +1,7 @@
 class CreateMediaReviewItemAuthor < ActiveRecord::Migration[6.1]
   def change
     create_table :media_review_item_authors, id: :uuid do |t|
-      t.text :type
+      t.text :_type
       t.text :name
       t.text :url
 

--- a/db/migrate/20210927200524_create_media_review_item_author.rb
+++ b/db/migrate/20210927200524_create_media_review_item_author.rb
@@ -1,0 +1,11 @@
+class CreateMediaReviewItemAuthor < ActiveRecord::Migration[6.1]
+  def change
+    create_table :media_review_item_authors, id: :uuid do |t|
+      t.text :type
+      t.text :name
+      t.text :url
+
+      t.belongs_to :media_review_item, type: :uuid, primary_key: :media_review_item_id, foreign_key: :id
+    end
+  end
+end

--- a/db/migrate/20210927202952_add_date_published_to_media_review.rb
+++ b/db/migrate/20210927202952_add_date_published_to_media_review.rb
@@ -1,0 +1,5 @@
+class AddDatePublishedToMediaReview < ActiveRecord::Migration[6.1]
+  def change
+    add_column :media_reviews, :date_published, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_14_145948) do
+ActiveRecord::Schema.define(version: 2021_09_27_202952) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -91,6 +91,32 @@ ActiveRecord::Schema.define(version: 2021_09_14_145948) do
     t.index ["instagram_post_id"], name: "index_instagram_videos_on_instagram_post_id"
   end
 
+  create_table "media_item_appearances", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "type"
+    t.text "description"
+    t.text "content_url"
+    t.text "archived_at"
+    t.uuid "media_review_item_id", null: false
+    t.index ["media_review_item_id"], name: "index_media_item_appearances_on_media_review_item_id"
+  end
+
+  create_table "media_review_authors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "type"
+    t.text "name"
+    t.text "url"
+  end
+
+  create_table "media_review_item_authors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "type"
+    t.text "name"
+    t.text "url"
+    t.uuid "media_review_item_id", null: false
+    t.index ["media_review_item_id"], name: "index_media_review_item_authors_on_media_review_item_id"
+  end
+
+  create_table "media_review_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  end
+
   create_table "media_reviews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -98,6 +124,7 @@ ActiveRecord::Schema.define(version: 2021_09_14_145948) do
     t.text "media_authenticity_category", null: false
     t.text "original_media_context_description", null: false
     t.uuid "archive_item_id", null: false
+    t.datetime "date_published"
     t.index ["archive_item_id"], name: "index_media_reviews_on_archive_item_id"
   end
 
@@ -182,6 +209,8 @@ ActiveRecord::Schema.define(version: 2021_09_14_145948) do
   add_foreign_key "api_keys", "users"
   add_foreign_key "instagram_images", "instagram_posts"
   add_foreign_key "instagram_videos", "instagram_posts"
+  add_foreign_key "media_item_appearances", "media_review_items"
+  add_foreign_key "media_review_item_authors", "media_review_items"
   add_foreign_key "media_reviews", "archive_items"
   add_foreign_key "twitter_images", "tweets"
   add_foreign_key "twitter_videos", "tweets"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 2021_09_27_202952) do
   end
 
   create_table "media_item_appearances", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.text "type"
+    t.text "_type"
     t.text "description"
     t.text "content_url"
     t.text "archived_at"
@@ -101,13 +101,15 @@ ActiveRecord::Schema.define(version: 2021_09_27_202952) do
   end
 
   create_table "media_review_authors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.text "type"
+    t.text "_type"
     t.text "name"
     t.text "url"
+    t.uuid "media_review_id", null: false
+    t.index ["media_review_id"], name: "index_media_review_authors_on_media_review_id"
   end
 
   create_table "media_review_item_authors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.text "type"
+    t.text "_type"
     t.text "name"
     t.text "url"
     t.uuid "media_review_item_id", null: false
@@ -115,6 +117,10 @@ ActiveRecord::Schema.define(version: 2021_09_27_202952) do
   end
 
   create_table "media_review_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "interpreted_as_claim"
+    t.uuid "media_review_id", null: false
+    t.index ["media_review_id"], name: "index_media_review_items_on_media_review_id"
+
   end
 
   create_table "media_reviews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -210,6 +216,8 @@ ActiveRecord::Schema.define(version: 2021_09_27_202952) do
   add_foreign_key "instagram_images", "instagram_posts"
   add_foreign_key "instagram_videos", "instagram_posts"
   add_foreign_key "media_item_appearances", "media_review_items"
+  add_foreign_key "media_review_authors", "media_reviews"
+  add_foreign_key "media_review_items", "media_reviews"
   add_foreign_key "media_review_item_authors", "media_review_items"
   add_foreign_key "media_reviews", "archive_items"
   add_foreign_key "twitter_images", "tweets"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,18 +39,18 @@ Sources::Tweet.create_from_url "https://twitter.com/dissectpodcast/status/140932
 
 archive_items = ArchiveItem.all
 
-MediaReview.create(original_media_link: "https://twitter.com/kairyssdal/status/1415029747826905090",
+MediaReviewModels::MediaReview.create(original_media_link: "https://twitter.com/kairyssdal/status/1415029747826905090",
                    media_authenticity_category: "real fake",
                    original_media_context_description: "not too much context",
                    archive_item_id: archive_items[0].id)
 
 
-MediaReview.create(original_media_link: "https://twitter.com/leahstokes/status/1414669810739281920",
+MediaReviewModels::MediaReview.create(original_media_link: "https://twitter.com/leahstokes/status/1414669810739281920",
                    media_authenticity_category: "Seems legit",
                    original_media_context_description: "This is an image and that's the context",
                    archive_item_id: archive_items[1].id)
 
-MediaReview.create(original_media_link: "https://twitter.com/dissectpodcast/status/1409323315735384064",
+MediaReviewModels::MediaReview.create(original_media_link: "https://twitter.com/dissectpodcast/status/1409323315735384064",
                    media_authenticity_category: "Might be real or fake",
                    original_media_context_description: "Image is warped",
                    archive_item_id: archive_items[2].id)

--- a/test/controllers/ingest_controller_test.rb
+++ b/test/controllers/ingest_controller_test.rb
@@ -105,6 +105,15 @@ class IngestControllerTest < ActionDispatch::IntegrationTest
 
     post = ArchiveItem.find(json["media_object_id"])
     assert_not_nil post
+
+    # Check that MediaReview and associated models were properly created
+    media_review = MediaReviewModels::MediaReview.first
+    assert_equal media_review.date_published, "2021-04-27"
+    assert_not_nil media_review.media_review_author
+    assert_equal media_review.media_review_author.name, "PolitiFact"
+    assert_not_nil media_review.media_review_item
+    assert_equal media_review.media_review_item.media_item_appearance[1]._type, "VideoObjectSnapshot"
+
   end
 
   test "can archive MediaReview from a webpage" do

--- a/test/controllers/text_search_controller_test.rb
+++ b/test/controllers/text_search_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TextSearchControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This PR adds several models corresponding to child attributes of the publicly posted `MediaReview` object schema. Several of the names are awkward right now, so I'm very open to change. 

## Testing
I've added a few asserts to an existing `IngestController` test. It can be run with the full suite using
`bin/rails t`

## Requirements
- Migration required

closes #93 