### PR TITLE
Log the user id of searchers

### DIFF
--- a/app/controllers/text_search_controller.rb
+++ b/app/controllers/text_search_controller.rb
@@ -1,5 +1,7 @@
 # typed: ignore
 class TextSearchController < ApplicationController
+  before_action :authenticate_user!
+
   sig { void }
   def index
     @search = TextSearch.new
@@ -18,7 +20,7 @@ class TextSearchController < ApplicationController
   def search
     typed_params = TypedParams[SubmitUrlParams].new.extract!(params)
     # Create a search object
-    search = TextSearch.create(query: typed_params.query)
+    search = TextSearch.create(query: typed_params.query, user_id: current_user.id)
     results = search.run
     @user_search_hits = results[:user_search_hits]
     @post_search_hits = results[:post_search_hits]

--- a/test/models/text_search_test.rb
+++ b/test/models/text_search_test.rb
@@ -22,5 +22,6 @@ class TextSearchTest < ActiveSupport::TestCase
     assert_not_nil results
     assert_equal results[:user_search_hits].length, 2  # POTUS, Biden Foundation
     assert_equal results[:post_search_hits].length, 2  # Greenwald tweet, Biden Foundation tweet
+    assert_equal TextSearch.all.length, 1
   end
 end


### PR DESCRIPTION
This PR ensures that a `user_id` is recorded when a search is made. The attribute was previously always null.    