### PR TITLE
Data export feature

### DIFF
--- a/app/controllers/archive_controller.rb
+++ b/app/controllers/archive_controller.rb
@@ -71,8 +71,9 @@ class ArchiveController < ApplicationController
     end
   end
 
+  # Export entire archive of reviewed media to a JSON File
   def export_archive_data
-    archive_json = helpers.prune_archive_items(ArchiveItem.all)
+    archive_json = ArchiveItem.prune_archive_items
     send_data archive_json, type: "application/json; header=present", disposition: "attachment; filename=archive.json"
   end
 end

--- a/app/controllers/archive_controller.rb
+++ b/app/controllers/archive_controller.rb
@@ -70,4 +70,9 @@ class ArchiveController < ApplicationController
       format.html { redirect_to :root }
     end
   end
+
+  def export_archive_data
+    archive_json = helpers.prune_archive_items(ArchiveItem.all)
+    send_data archive_json, type: "application/json; header=present", disposition: "attachment; filename=archive.json"
+  end
 end

--- a/app/controllers/instagram_users_controller.rb
+++ b/app/controllers/instagram_users_controller.rb
@@ -3,4 +3,16 @@ class InstagramUsersController < ApplicationController
     @instagram_user = Sources::InstagramUser.find(params[:id])
     @archive_items = Sources::InstagramPost.where(author_id: @instagram_user.id).includes([:images, :videos])
   end
+
+  # Exports all media items created by the currently viewed Instagram user to a JSON file
+  def export_instagram_user_data
+    instagram_post_archive_items = ArchiveItem.includes(archivable_item: [:author])
+                                     .where(archivable_item_type: "Sources::InstagramPost")
+    instagram_user = Sources::InstagramUser.find(params[:id])
+    instagram_posts_by_user = instagram_post_archive_items.select { |t| t.instagram_post.author == instagram_user }
+    instagram_post_archive_json = ArchiveItem.prune_archive_items(instagram_posts_by_user)
+    send_data instagram_post_archive_json,
+              type: "application/json; header=present",
+              disposition: "attachment; filename=#{instagram_user.display_name.parameterize(separator: '_')}_instagram_archive.json"
+  end
 end

--- a/app/controllers/twitter_users_controller.rb
+++ b/app/controllers/twitter_users_controller.rb
@@ -5,14 +5,15 @@ class TwitterUsersController < ApplicationController
     @archive_items = Sources::Tweet.where(author_id: @twitter_user.id).includes([:images, :videos])
   end
 
+  # Exports all media items created by the currently viewed Twitter user to a JSON file
   def export_tweeter_data
-    twitter_user = Sources::TwitterUser.find(params[:id])
     tweet_archive_items = ArchiveItem.includes(archivable_item: [:author])
                                      .where(archivable_item_type: "Sources::Tweet")
+    twitter_user = Sources::TwitterUser.find(params[:id])
     tweets_by_author = tweet_archive_items.select { |t| t.tweet.author == twitter_user }
-    tweet_archive_json = helpers.prune_archive_items(tweets_by_author)
+    tweet_archive_json = ArchiveItem.prune_archive_items(tweets_by_author)
     send_data tweet_archive_json,
               type: "application/json; header=present",
-              disposition: "attachment; filename=#{twitter_user.display_name.parameterize(separator: '_')}_archive.json"
+              disposition: "attachment; filename=#{twitter_user.display_name.parameterize(separator: '_')}_twitter_archive.json"
   end
 end

--- a/app/controllers/twitter_users_controller.rb
+++ b/app/controllers/twitter_users_controller.rb
@@ -4,4 +4,15 @@ class TwitterUsersController < ApplicationController
     @twitter_user = Sources::TwitterUser.find(params[:id])
     @archive_items = Sources::Tweet.where(author_id: @twitter_user.id).includes([:images, :videos])
   end
+
+  def export_tweeter_data
+    twitter_user = Sources::TwitterUser.find(params[:id])
+    tweet_archive_items = ArchiveItem.includes(archivable_item: [:author])
+                                     .where(archivable_item_type: "Sources::Tweet")
+    tweets_by_author = tweet_archive_items.select { |t| t.tweet.author == twitter_user }
+    tweet_archive_json = helpers.prune_archive_items(tweets_by_author)
+    send_data tweet_archive_json,
+              type: "application/json; header=present",
+              disposition: "attachment; filename=#{twitter_user.display_name.parameterize(separator: '_')}_archive.json"
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,3 @@
 # typed: strict
 module ApplicationHelper
-  def prune_archive_items(relation)
-    relation.to_json(only: [:id, :created_at],
-                     include: [ { media_review: { except: [:id, :created_at, :updated_at, :archive_item_id] } },
-                                { archivable_item: { include: { author: { only: [:handle, :display_name, :twitter_id] } },
-                                                     except: [:language, :author_id, :id] }
-                                }])
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,10 @@
 # typed: strict
 module ApplicationHelper
+  def prune_archive_items(relation)
+    relation.to_json(only: [:id, :created_at],
+                     include: [ { media_review: { except: [:id, :created_at, :updated_at, :archive_item_id] } },
+                                { archivable_item: { include: { author: { only: [:handle, :display_name, :twitter_id] } },
+                                                     except: [:language, :author_id, :id] }
+                                }])
+  end
 end

--- a/app/models/archive_item.rb
+++ b/app/models/archive_item.rb
@@ -35,6 +35,18 @@ class ArchiveItem < ApplicationRecord
     object
   end
 
+  # Returns an array of ArchiveItems modiefied for JSON export
+  def self.prune_archive_items(relation = nil)
+    unless relation
+      relation = ArchiveItem.includes(:media_review, archivable_item: [:author])
+    end
+    relation.to_json(only: [:id, :created_at],
+                     include: [ { media_review: { except: [:id, :created_at, :updated_at, :archive_item_id] } },
+                                { archivable_item: { include: { author: { only: [:handle, :display_name, :twitter_id] } },
+                                                     except: [:language, :author_id, :id] }
+                                }])
+  end
+
   # Return a class that can handle a given +url+
   sig { params(url: String).returns(T.nilable(Class)) }
   def self.model_for_url(url)

--- a/app/views/archive/index.html.erb
+++ b/app/views/archive/index.html.erb
@@ -9,6 +9,11 @@
         <i class="fas fa-plus-square"></i>
         <% end %>
       </a>
+      <a href="#">
+        <%= link_to archive_download_path do %>
+          ↓
+        <% end %>
+      </a>
     </div>
   </div>
   <div class="mt-4 mx-1">

--- a/app/views/instagram_users/show.html.erb
+++ b/app/views/instagram_users/show.html.erb
@@ -20,7 +20,7 @@
     <div class="flex">
       <h1 class="text-xl text-green-400 font-medium title-font mb-4">Archived Media Items</h1>
       <a class="px-2" href="#">
-        <%= link_to user_download_path do %>
+        <%= link_to instagram_user_download_path do %>
           <span class="text-xl font-medium title-font mb-4">↓</span>
         <% end %>
       </a>

--- a/app/views/instagram_users/show.html.erb
+++ b/app/views/instagram_users/show.html.erb
@@ -17,9 +17,13 @@
         </ul>
       </div>
     </div>
-    <div>
+    <div class="flex">
       <h1 class="text-xl text-green-400 font-medium title-font mb-4">Archived Media Items</h1>
-      <div class="h-1 w-50 bg-pink-200 rounded"></div>
+      <a class="px-2" href="#">
+        <%= link_to user_download_path do %>
+          <span class="text-xl font-medium title-font mb-4">↓</span>
+        <% end %>
+      </a>
     </div>
     <div class="flex flex-wrap-m-4">
       <% @archive_items.each do |instagram_post| %>

--- a/app/views/twitter_users/show.html.erb
+++ b/app/views/twitter_users/show.html.erb
@@ -19,15 +19,15 @@
         </ul>
       </div>
     </div>
-    <div>
+    <div class="flex">
       <h1 class="text-xl text-green-400 font-medium title-font mb-4">Archived Media Items</h1>
-      <a href="#">
+      <a class="px-2" href="#">
         <%= link_to user_download_path do %>
-          ↓
+          <span class="text-xl font-medium title-font mb-4">↓</span>
         <% end %>
       </a>
-      <div class="h-1 w-50 bg-pink-200 rounded"></div>
     </div>
+    <div class="h-1 w-50 bg-pink-200 rounded"></div>
     <div class="flex flex-wrap-m-4">
       <% @archive_items.each do |tweet| %>
       <div class="xl:w-1/2 md:w-1 p-4">

--- a/app/views/twitter_users/show.html.erb
+++ b/app/views/twitter_users/show.html.erb
@@ -22,7 +22,7 @@
     <div class="flex">
       <h1 class="text-xl text-green-400 font-medium title-font mb-4">Archived Media Items</h1>
       <a class="px-2" href="#">
-        <%= link_to user_download_path do %>
+        <%= link_to twitter_user_download_path do %>
           <span class="text-xl font-medium title-font mb-4">↓</span>
         <% end %>
       </a>

--- a/app/views/twitter_users/show.html.erb
+++ b/app/views/twitter_users/show.html.erb
@@ -21,6 +21,11 @@
     </div>
     <div>
       <h1 class="text-xl text-green-400 font-medium title-font mb-4">Archived Media Items</h1>
+      <a href="#">
+        <%= link_to user_download_path do %>
+          ↓
+        <% end %>
+      </a>
       <div class="h-1 w-50 bg-pink-200 rounded"></div>
     </div>
     <div class="flex flex-wrap-m-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
   post "/settings/deny", to: "settings#denyUserRequest", as: "deny_request"
 
   resources :twitter_users, only: [:show]
-  get "/twitter_users/:id/download", to: "twitter_users#export_tweeter_data", as: "user_download"
   resources :instagram_users, only: [:show]
+  get "/instagram_users/:id/download", to: "instagram_users#export_instagram_user_data", as: "instagram_user_download"
+  get "/twitter_users/:id/download", to: "twitter_users#export_tweeter_data", as: "twitter_user_download"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
   get "/archive/add", to: "archive#add"
   post "/archive/add", to: "archive#submit_url"
 
+  get "/archive/download", to: "archive#export_archive_data", as: "archive_download"
+
   post "/ingest/submit_media_review", to: "ingest#submit_media_review", as: "ingest_api_raw"
   post "/ingest/submit_media_review_source", to: "ingest#submit_media_review_source", as: "ingest_api_url"
 
@@ -26,5 +28,6 @@ Rails.application.routes.draw do
   post "/settings/deny", to: "settings#denyUserRequest", as: "deny_request"
 
   resources :twitter_users, only: [:show]
+  get "/twitter_users/:id/download", to: "twitter_users#export_tweeter_data", as: "user_download"
   resources :instagram_users, only: [:show]
 end

--- a/db/migrate/20210914145948_create_media_review.rb
+++ b/db/migrate/20210914145948_create_media_review.rb
@@ -5,10 +5,7 @@ class CreateMediaReview < ActiveRecord::Migration[6.1]
       t.text :original_media_link, null: false
       t.text :media_authenticity_category, null: false
       t.text :original_media_context_description, null: false
-      # t.belongs_to :tweet, type: :uuid, foreign_key: true
-      # t.belongs_to :instagram_post, type: :uuid, foreign_key: true
       t.belongs_to :archive_item, type: :uuid, primary_key: :archive_item_id, foreign_key: :id
-      # has_one claimreview?
     end
   end
 end

--- a/test/models/archive_item_test.rb
+++ b/test/models/archive_item_test.rb
@@ -1,8 +1,15 @@
 # typed: strict
 require "test_helper"
 
-class ArchiveItemTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+class ArchiveItemTest < ActionDispatch::IntegrationTest
+  test "can generate ArchiveItem JSON export" do
+    post ingest_api_url_path, params: { url: "https://oneroyalace.github.io/MediaReview-Fodder/single_embedded_media_review.html", api_key: "123456789" } # archive post with mediareview
+    archive_json = JSON.parse(ArchiveItem.prune_archive_items)
+
+    assert_equal archive_json.length, 1
+    assert_equal archive_json[0]["media_review"]["original_media_link"], "https://twitter.com/MariahCarey/status/1438419033267871746"
+    # assert_equal archive_json[0]["media_review"]["media_authenticity_category"], "DecontextualizedContent"
+    assert_equal archive_json[0]["archivable_item"]["author"]["handle"], "MariahCarey"
+    assert_not_includes archive_json[0]["media_review"], "id"
+  end
 end


### PR DESCRIPTION
This PR creates a feature that lets users export data from the archive, either from the archive home page (exporting details of every item in the full archive) or from a social media user page (exporting details on only the media authored by that user). 

closes #98 