### PR TITLE
Add methods to run scrapers in ActiveJob

### DIFF
--- a/app/jobs/scraper_job.rb
+++ b/app/jobs/scraper_job.rb
@@ -1,0 +1,8 @@
+class ScraperJob < ApplicationJob
+  queue_as :default
+
+  def perform(media_source_class, media_model, url)
+    media_item = media_source_class.extract(url)
+    media_model.create_from_hash(media_item)
+  end
+end

--- a/app/models/sources/instagram_post.rb
+++ b/app/models/sources/instagram_post.rb
@@ -38,16 +38,29 @@ class Sources::InstagramPost < ApplicationRecord
     false
   end
 
-  # Create a +ArchiveItem+ from a +url+ as a string
+  # Create an +ArchiveItem+ from a +url+ as a string
   #
   # @!scope class
   # @params url String a string of a url
-  # returns ArchiveItem with type InstagramPost that have been
-  #   saved to the graph database
+  # returns ArchiveItem with type InstagramPost that has been saved to the database
   sig { params(url: String).returns(ArchiveItem) }
   def self.create_from_url(url)
     zorki_post = InstagramMediaSource.extract(url)
     Sources::InstagramPost.create_from_zorki_hash(zorki_post).first
+  end
+
+  # Spawns an ActiveJob tasked with creating an +ArchiveItem+ from a +url+ as a string
+  #
+  # @!scope class
+  # @params url String a string of a url
+  # returns ScraperJob
+  sig { params(url: String).returns(ScraperJob) }
+  def self.create_from_url!(url)
+    ScraperJob.perform_later(InstagramMediaSource, Sources::InstagramPost, url)
+  end
+
+  def self.create_from_hash(zorki_posts)
+    create_from_zorki_hash(zorki_posts)
   end
 
   # Create a +ArchiveItem+ from a +Zorki::Post+

--- a/test/models/instagram_post_test.rb
+++ b/test/models/instagram_post_test.rb
@@ -29,6 +29,12 @@ class InstagramPostTest < ActiveSupport::TestCase
     assert_not_nil Sources::InstagramPost.create_from_url("https://www.instagram.com/p/CBcqOkyDDH8/?utm_source=ig_embed")
   end
 
+  test "can create from Instagram url using ActiveJob" do
+    Sources::InstagramPost.create_from_url!("https://www.instagram.com/p/CBcqOkyDDH8/?utm_source=ig_embed")
+    perform_enqueued_jobs
+    assert_not_nil Sources::InstagramPost.where(instagram_id: "CBcqOkyDDH8")
+  end
+
   test "can create two tweets from same author" do
     @zorki_post2 = InstagramMediaSource.extract("https://www.instagram.com/p/CQDeYPhMJLG/")
     archive_item = Sources::InstagramPost.create_from_zorki_hash(@zorki_post).first.instagram_post

--- a/test/models/tweet_test.rb
+++ b/test/models/tweet_test.rb
@@ -2,6 +2,8 @@
 require "test_helper"
 
 class TweetTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   def setup
     @birdsong_tweet = TwitterMediaSource.extract("https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
     @birdsong_tweet2 = TwitterMediaSource.extract("https://twitter.com/AmtrakNECAlerts/status/1400055826170191874")
@@ -28,10 +30,23 @@ class TweetTest < ActiveSupport::TestCase
     assert_not_nil archive_item.tweet.images
   end
 
-  test "can create from Tweet url" do
-    assert_not_nil Sources::Tweet.create_from_url("https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
-    # a slightly different URL
-    assert_not_nil Sources::Tweet.create_from_url("https://twitter.com/Citruscrush/status/1094999286281048070?fbclid=IwAR20aObVHvlSdu-e2L2mTHXytMqgoGvH6tur4vLz0bU4E2p5k4NciEOAgiE")
+  test "can archive Tweet from url" do
+    tweet = Sources::Tweet.create_from_url("https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
+    tweet_2 = Sources::Tweet.create_from_url("https://twitter.com/Citruscrush/status/1094999286281048070?fbclid=IwAR20aObVHvlSdu-e2L2mTHXytMqgoGvH6tur4vLz0bU4E2p5k4NciEOAgiE")
+    assert_not_nil tweet
+    assert_not_nil tweet_2
+  end
+
+  test "can archive tweet from url using ActiveJob" do
+    Sources::Tweet.create_from_url!("https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
+    Sources::Tweet.create_from_url!("https://twitter.com/Citruscrush/status/1094999286281048070?fbclid=IwAR20aObVHvlSdu-e2L2mTHXytMqgoGvH6tur4vLz0bU4E2p5k4NciEOAgiE")
+    perform_enqueued_jobs
+
+    tweet_1 = Sources::Tweet.where(twitter_id: 1397922363551870990).first
+    tweet_2 = Sources::Tweet.where(twitter_id: 1094999286281048070).first
+
+    assert_not_nil tweet_1
+    assert_not_nil tweet_2
   end
 
   test "can create two tweets from same author" do


### PR DESCRIPTION
This PR adds a new method, `create_from_url!`, to the `tweet` and `InstagramPost` media models, which spawns an ActiveJob tasked with scraping and archiving a post.

To test:
- Pull this branch
- run `rails t`

Closes #106 