### PR TITLE
Distinguish GIFs from other twitter videos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,7 @@ gem "streamio-ffmpeg"
 # gem "birdsong", "0.1.0", path: "~/Repositories/birdsong" # twitter
 
 # gem "zorki", "0.1.0", git: "https://github.com/cguess/zorki"
-gem "birdsong", "0.1.0", git: "https://github.com/cguess/birdsong"
+gem "birdsong", "0.1.0", git: "https://github.com/cguess/birdsong", branch: "archive-gifs"
 gem "forki", git: "https://github.com/oneroyalace/forki"
 
 # A progress bar for our Rake tasks

--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,7 @@ gem "streamio-ffmpeg"
 # gem "birdsong", "0.1.0", path: "~/Repositories/birdsong" # twitter
 
 # gem "zorki", "0.1.0", git: "https://github.com/cguess/zorki"
-gem "birdsong", "0.1.0", git: "https://github.com/cguess/birdsong", branch: "archive-gifs"
+gem "birdsong", "0.1.0", git: "https://github.com/cguess/birdsong"
 gem "forki", git: "https://github.com/oneroyalace/forki"
 
 # A progress bar for our Rake tasks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/cguess/birdsong
-  revision: d314c04b11376db0f623289a8f24068a72f76c17
+  revision: 95498447f2272d757986c292ed8376d11023a7dc
+  branch: archive-gifs
   specs:
     birdsong (0.1.0)
       oauth (~> 0.5.6)
@@ -210,6 +211,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.1-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-linux)
+      racc (~> 1.4)
     oauth (0.5.8)
     oj (3.13.11)
     orm_adapter (0.5.0)
@@ -321,9 +324,6 @@ GEM
       tty-screen (~> 0.8.1)
     rubyzip (2.3.2)
     safe_type (1.1.1)
-    scenic (1.5.5)
-      activerecord (>= 4.0.0)
-      railties (>= 4.0.0)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -356,6 +356,7 @@ GEM
       sorbet-runtime (>= 0.5)
     sorbet-runtime (0.5.9519)
     sorbet-static (0.5.9519-universal-darwin-21)
+    sorbet-static (0.5.9519-x86_64-linux)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
@@ -454,7 +455,6 @@ DEPENDENCIES
   rubocop-sorbet
   ruby-progressbar
   ruby_jard
-  scenic (~> 1.5.4)
   selenium-webdriver
   shrine (~> 3.0)
   sidekiq (~> 6.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: https://github.com/cguess/birdsong
-  revision: 95498447f2272d757986c292ed8376d11023a7dc
-  branch: archive-gifs
+  revision: 24d87688d1750686ae22fd4f848cce39c0fe098b
   specs:
     birdsong (0.1.0)
       oauth (~> 0.5.6)
@@ -211,6 +210,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.1-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
     oauth (0.5.8)
@@ -355,6 +356,7 @@ GEM
       sorbet-coerce (>= 0.2.6)
       sorbet-runtime (>= 0.5)
     sorbet-runtime (0.5.9519)
+    sorbet-static (0.5.9519-universal-darwin-19)
     sorbet-static (0.5.9519-universal-darwin-21)
     sorbet-static (0.5.9519-x86_64-linux)
     sorted_set (1.0.3)
@@ -419,6 +421,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES

--- a/app/models/sources/tweet.rb
+++ b/app/models/sources/tweet.rb
@@ -84,7 +84,7 @@ class Sources::Tweet < ApplicationRecord
       end
 
       video_attributes = birdsong_tweet.video_file_names.map do |video_file_name|
-        { video: File.open(video_file_name.first, binmode: true) }
+        { video: File.open(video_file_name.first, binmode: true), video_type: birdsong_tweet.video_file_type }
       end
 
       tweet_hash = {

--- a/app/views/archive/_item_media_preview.html.erb
+++ b/app/views/archive/_item_media_preview.html.erb
@@ -1,12 +1,22 @@
 <% if item.images.empty? == false %>
 <img src="<%= item.images.first.image_url %>" />
 <% elsif item.videos.empty? == false %>
-<video
-  width="320"
-  height="240"
-  poster="<%= item.videos.first.video_derivatives[:preview].url %>"
-  controls >
-  <source src="<%= item.videos.first.video_url %>" type="video/mp4">
-  Your browser does not support the video tag.
-</video>
+  <div>
+    <figure class="relative m-0 text-center">
+      <video
+        width="320"
+        height="240"
+        poster="<%= item.videos.first.video_derivatives[:preview].url %>"
+        controls >
+        <source src="<%= item.videos.first.video_url %>" type="video/mp4">
+        Your browser does not support the video tag.
+      </video>
+      <% if item.videos.first.video_type == "animated_gif" %>
+        <figcaption class="absolute text-white w-1/12 top-0 text-base bg-yellow-300">
+          GIF
+        </figcaption>
+      <% end %>
+    </figure>
+ </div>
 <% end %>
+

--- a/db/migrate/20210708172459_create_image_searches.rb
+++ b/db/migrate/20210708172459_create_image_searches.rb
@@ -5,6 +5,7 @@ class CreateImageSearches < ActiveRecord::Migration[6.1]
     create_table :image_searches, id: :uuid do |t|
       t.string :dhash, nil: false
       t.jsonb  :image_data, nil: false
+      t.belongs_to :user, type: :uuid, primary_key: :user_id, foreign_key: :id
       t.timestamps
     end
   end

--- a/db/migrate/20220203211301_add_type_to_twitter_videos.rb
+++ b/db/migrate/20220203211301_add_type_to_twitter_videos.rb
@@ -1,0 +1,5 @@
+class AddTypeToTwitterVideos < ActiveRecord::Migration[7.0]
+  def change
+    add_column :twitter_videos, :video_type, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_14_161106) do
+ActiveRecord::Schema.define(version: 2022_02_03_211301) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2022_01_14_161106) do
 
   create_table "api_keys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "hashed_api_key"
-    t.uuid "user_id"
+    t.uuid "user_id", null: false
     t.date "last_used"
     t.jsonb "usage_logs"
     t.datetime "created_at", precision: 6, null: false
@@ -94,6 +94,8 @@ ActiveRecord::Schema.define(version: 2022_01_14_161106) do
     t.jsonb "image_data"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "user_id", null: false
+    t.index ["user_id"], name: "index_image_searches_on_user_id"
   end
 
   create_table "instagram_images", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -163,6 +165,8 @@ ActiveRecord::Schema.define(version: 2022_01_14_161106) do
     t.uuid "searchable_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.virtual "content_tsvector", type: :tsvector, as: "to_tsvector('english'::regconfig, content)", stored: true
+    t.index ["content_tsvector"], name: "index_pg_search_documents_on_content_tsvector", using: :gin
     t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable"
   end
 
@@ -213,6 +217,7 @@ ActiveRecord::Schema.define(version: 2022_01_14_161106) do
     t.jsonb "video_data"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "video_type"
     t.index ["tweet_id"], name: "index_twitter_videos_on_tweet_id"
   end
 
@@ -250,6 +255,7 @@ ActiveRecord::Schema.define(version: 2022_01_14_161106) do
   add_foreign_key "api_keys", "users"
   add_foreign_key "facebook_images", "facebook_posts"
   add_foreign_key "facebook_videos", "facebook_posts"
+  add_foreign_key "image_searches", "users"
   add_foreign_key "instagram_images", "instagram_posts"
   add_foreign_key "instagram_videos", "instagram_posts"
   add_foreign_key "media_reviews", "archive_items"
@@ -257,5 +263,4 @@ ActiveRecord::Schema.define(version: 2022_01_14_161106) do
   add_foreign_key "text_searches", "users"
   add_foreign_key "twitter_images", "tweets"
   add_foreign_key "twitter_videos", "tweets"
-
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -94,7 +94,7 @@ ActiveRecord::Schema.define(version: 2022_02_03_211301) do
     t.jsonb "image_data"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.uuid "user_id", null: false
+    t.uuid "user_id"
     t.index ["user_id"], name: "index_image_searches_on_user_id"
   end
 
@@ -174,7 +174,7 @@ ActiveRecord::Schema.define(version: 2022_02_03_211301) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "query"
-    t.uuid "user_id", null: false
+    t.uuid "user_id"
     t.index ["user_id"], name: "index_text_searches_on_user_id"
   end
 

--- a/test/models/image_search_test.rb
+++ b/test/models/image_search_test.rb
@@ -34,6 +34,6 @@ class ImageSearchTest < ActiveSupport::TestCase
       end
     end
     assert in_order, "Images should be returned in order of similarity (lower is better)"
-    assert_equal 0, results.first[:score], "First image should be equal to passed in image"
+    assert results.first[:score] <= 1 # Identical images have score 0, but downloading images may introduce artifacts, so we add some tolerance
   end
 end


### PR DESCRIPTION
This PR works in tandem with https://github.com/cguess/birdsong/pull/7, which allows Birdsong to archive and distinguish Tweets containing gifs. 

The PR adds the attribute `video_type` to the `TwitterVideo` model, allowing us to mark gifs in the archive's media previews. E.g.: 

![image](https://user-images.githubusercontent.com/9507998/152560603-bf3f3fa3-2130-4a06-95d1-98635c58cc34.png)

Closes #116 

### Testing
1. `rails db:migrate`
2. `bundle install`
3. `rails t`

### Merge notes
We should merge https://github.com/cguess/birdsong/pull/7 before merging this PR. After that happens, we should change the Gemfile on this branch to point to `birdsong/master` instead of `birdsong/archive-gifs`