### PR TITLE
remediate past migration sins

### DIFF
--- a/db/migrate/20210708172459_create_image_searches.rb
+++ b/db/migrate/20210708172459_create_image_searches.rb
@@ -5,7 +5,6 @@ class CreateImageSearches < ActiveRecord::Migration[6.1]
     create_table :image_searches, id: :uuid do |t|
       t.string :dhash, nil: false
       t.jsonb  :image_data, nil: false
-      t.belongs_to :user, type: :uuid, primary_key: :user_id, foreign_key: :id
       t.timestamps
     end
   end

--- a/db/migrate/20220103202619_add_user_to_image_searches.rb
+++ b/db/migrate/20220103202619_add_user_to_image_searches.rb
@@ -1,5 +1,0 @@
-class AddUserToImageSearches < ActiveRecord::Migration[6.1]
-  def change
-    add_reference :image_searches, :submitter, index: true, type: :uuid
-  end
-end

--- a/db/migrate/20220302174537_add_user_reference_to_image_searches.rb
+++ b/db/migrate/20220302174537_add_user_reference_to_image_searches.rb
@@ -1,0 +1,5 @@
+class AddUserReferenceToImageSearches < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :image_searches, :user, index: true, type: :uuid, foreign_key: true
+  end
+end

--- a/db/migrate/20220303150343_add_user_foreign_key_to_text_searches.rb
+++ b/db/migrate/20220303150343_add_user_foreign_key_to_text_searches.rb
@@ -1,0 +1,5 @@
+class AddUserForeignKeyToTextSearches < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :text_searches, :users, column: :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_02_174537) do
+ActiveRecord::Schema.define(version: 2022_03_03_150343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -273,6 +273,7 @@ ActiveRecord::Schema.define(version: 2022_03_02_174537) do
   add_foreign_key "instagram_videos", "instagram_posts"
   add_foreign_key "media_reviews", "archive_items"
   add_foreign_key "organizations", "users", column: "admin_id"
+  add_foreign_key "text_searches", "users"
   add_foreign_key "twitter_images", "tweets"
   add_foreign_key "twitter_videos", "tweets"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_03_211301) do
+ActiveRecord::Schema.define(version: 2022_03_02_174537) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -21,7 +22,7 @@ ActiveRecord::Schema.define(version: 2022_02_03_211301) do
 
   create_table "api_keys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "hashed_api_key"
-    t.uuid "user_id", null: false
+    t.uuid "user_id"
     t.date "last_used"
     t.jsonb "usage_logs"
     t.datetime "created_at", precision: 6, null: false
@@ -49,24 +50,24 @@ ActiveRecord::Schema.define(version: 2022_02_03_211301) do
 
   create_table "facebook_images", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "facebook_post_id"
-    t.string "dhash"
     t.jsonb "image_data"
+    t.string "dhash"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["facebook_post_id"], name: "index_facebook_images_on_facebook_post_id"
   end
 
   create_table "facebook_posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "posted_at"
     t.text "text"
-    t.datetime "posted_at", precision: 6
     t.text "facebook_id"
+    t.uuid "author_id", null: false
     t.jsonb "reactions"
     t.integer "num_comments"
     t.integer "num_shares"
     t.integer "num_views"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.uuid "author_id", null: false
     t.text "url", null: false
     t.index ["author_id"], name: "index_facebook_posts_on_author_id"
   end
@@ -114,7 +115,7 @@ ActiveRecord::Schema.define(version: 2022_02_03_211301) do
   create_table "instagram_posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "text", null: false
     t.string "instagram_id", null: false
-    t.datetime "posted_at", precision: 6, null: false
+    t.datetime "posted_at", null: false
     t.integer "number_of_likes", null: false
     t.uuid "author_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -195,7 +196,7 @@ ActiveRecord::Schema.define(version: 2022_02_03_211301) do
     t.string "twitter_id", null: false
     t.string "language", null: false
     t.uuid "author_id", null: false
-    t.datetime "posted_at", precision: 6, null: false
+    t.datetime "posted_at", null: false
     t.index ["author_id"], name: "index_tweets_on_author_id"
   end
 
@@ -211,7 +212,7 @@ ActiveRecord::Schema.define(version: 2022_02_03_211301) do
   create_table "twitter_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "handle", null: false
     t.string "display_name", null: false
-    t.datetime "sign_up_date", precision: 6, null: false
+    t.datetime "sign_up_date", null: false
     t.string "twitter_id", null: false
     t.text "description", null: false
     t.string "url", null: false
@@ -237,20 +238,20 @@ ActiveRecord::Schema.define(version: 2022_02_03_211301) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: 6
-    t.datetime "remember_created_at", precision: 6
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at", precision: 6
-    t.datetime "last_sign_in_at", precision: 6
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.string "confirmation_token"
-    t.datetime "confirmed_at", precision: 6
-    t.datetime "confirmation_sent_at", precision: 6
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
-    t.datetime "locked_at", precision: 6
+    t.datetime "locked_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "approved", default: false, null: false
@@ -268,12 +269,10 @@ ActiveRecord::Schema.define(version: 2022_02_03_211301) do
   add_foreign_key "facebook_images", "facebook_posts"
   add_foreign_key "facebook_videos", "facebook_posts"
   add_foreign_key "image_searches", "users"
-  add_foreign_key "text_searches", "users"
   add_foreign_key "instagram_images", "instagram_posts"
   add_foreign_key "instagram_videos", "instagram_posts"
   add_foreign_key "media_reviews", "archive_items"
   add_foreign_key "organizations", "users", column: "admin_id"
   add_foreign_key "twitter_images", "tweets"
   add_foreign_key "twitter_videos", "tweets"
-
 end


### PR DESCRIPTION
Long ago in a galaxy not so far from our own, I retroactively edited a database migration. Bad idea. In editing the old migration, I referenced a table created by a future migration, which effectively nuked the migration history chain.

In this PR, I undo my edit to the old [migration](https://github.com/TechAndCheck/zenodotus/blob/8b601562f16aa286338e795beab0060aa841aa5d/db/migrate/20210708172459_create_image_searches.rb) and copy its changes into [a new migration](https://github.com/TechAndCheck/zenodotus/blob/8b601562f16aa286338e795beab0060aa841aa5d/db/migrate/20220302174537_add_user_reference_to_image_searches.rb). This fixes the migration history chain. 

### Testing
1. Merge https://github.com/TechAndCheck/zenodotus/pull/148 or cherry-pick its changes into this branch
1. `rails db:drop`
2. `rails db:create`
3. `rails db:migrate`
Without this PR, the db migration above will fail. With these changes, it works. 

As always. `rails t`. 