### PR TITLE
Fix Hypatia integration, sorbet types, and tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,8 +212,6 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.1-x86_64-linux)
-      racc (~> 1.4)
     nokogiri (1.13.1-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)

--- a/app/models/sources/facebook_post.rb
+++ b/app/models/sources/facebook_post.rb
@@ -41,7 +41,7 @@ class Sources::FacebookPost < ApplicationRecord
   # @params user the user adding the ArchiveItem
   # returns ArchiveItem with type InstagramPost that have been
   #   saved to the graph database
-  sig { params(url: String, user: T.nilable(User)).returns(ArchiveItem) }
+  sig { params(url: String, user: T.nilable(User)).returns(ScraperJob) }
   def self.create_from_url(url, user = nil)
     ScraperJob.perform_later(FacebookMediaSource, Sources::FacebookPost, url, user)
   end
@@ -52,7 +52,7 @@ class Sources::FacebookPost < ApplicationRecord
   # @params url String a string of a url
   # @params user The user adding the ArchiveItem
   # returns ScraperJob
-  sig { params(url: String, user: T.nilable(User)).returns(ScraperJob) }
+  sig { params(url: String, user: T.nilable(User)).returns(ArchiveItem) }
   def self.create_from_url!(url, user = nil)
     forki_response = FacebookMediaSource.extract(url, true)
     raise "Error sending job to Forki" unless forki_response.respond_to?(:first) && forki_response.first.has_key?("id")
@@ -77,6 +77,7 @@ class Sources::FacebookPost < ApplicationRecord
   sig { params(forki_posts: T::Array[Hash], user: T.nilable(User)).returns(T::Array[ArchiveItem]) }
   def self.create_from_forki_hash(forki_posts, user = nil)
     forki_posts.map do |forki_post|
+      forki_post = forki_post["post"]
       facebook_user = Sources::FacebookUser.create_from_forki_hash([forki_post["user"]]).first.facebook_user
 
       unless forki_post["image_file"].nil?

--- a/app/models/sources/instagram_post.rb
+++ b/app/models/sources/instagram_post.rb
@@ -81,6 +81,7 @@ class Sources::InstagramPost < ApplicationRecord
   sig { params(zorki_posts: T::Array[Hash], user: T.nilable(User)).returns(T::Array[ArchiveItem]) }
   def self.create_from_zorki_hash(zorki_posts, user = nil)
     zorki_posts.map do |zorki_post|
+      zorki_post = zorki_post["post"]
       instagram_user = Sources::InstagramUser.create_from_zorki_hash([zorki_post["user"]]).first.instagram_user
 
       unless zorki_post["image_files"].nil?

--- a/test/models/facebook_post_test.rb
+++ b/test/models/facebook_post_test.rb
@@ -17,11 +17,11 @@ class FacebookPostTest < ActiveSupport::TestCase
     assert_not_nil archive_item
     assert_kind_of ArchiveItem, archive_item
 
-    assert_equal @forki_post.first["text"], archive_item.facebook_post.text
+    assert_equal @forki_post.first["post"]["text"], archive_item.facebook_post.text
     assert_equal @forki_post.first["id"], archive_item.facebook_post.facebook_id
     assert_equal @forki_post.first["id"], archive_item.service_id
-    assert_equal @forki_post.first["url"], archive_item.facebook_post.url
-    assert_equal Time.at(@forki_post.first["created_at"]).utc.strftime("%FT%T%:z"), archive_item.facebook_post.posted_at.strftime("%FT%T%:z")
+    assert_equal @forki_post.first["post"]["url"], archive_item.facebook_post.url
+    assert_equal Time.at(@forki_post.first["post"]["created_at"]).utc.strftime("%FT%T%:z"), archive_item.facebook_post.posted_at.strftime("%FT%T%:z")
 
     assert_not_nil archive_item.facebook_post.author
     assert_not_nil archive_item.facebook_post.images

--- a/test/models/facebook_user_test.rb
+++ b/test/models/facebook_user_test.rb
@@ -4,7 +4,7 @@ class FacebookUserTest < ActiveSupport::TestCase
   def setup
     @forki_user = FacebookMediaSource.extract(
       "https://www.facebook.com/Meta/photos/a.108824087345859/336596487901950", true
-    ).first["user"]
+    ).first["post"]["user"]
   end
 
   def teardown

--- a/test/models/instagram_post_test.rb
+++ b/test/models/instagram_post_test.rb
@@ -17,10 +17,10 @@ class InstagramPostTest < ActiveSupport::TestCase
     assert_not_nil archive_item
     assert_kind_of ArchiveItem, archive_item
 
-    assert_equal @zorki_post.first["text"], archive_item.instagram_post.text
+    assert_equal @zorki_post.first["post"]["text"], archive_item.instagram_post.text
     assert_equal @zorki_post.first["id"], archive_item.instagram_post.instagram_id
     assert_equal @zorki_post.first["id"], archive_item.service_id
-    assert_equal @zorki_post.first["date"], archive_item.instagram_post.posted_at.strftime("%FT%T%:z")
+    assert_equal @zorki_post.first["post"]["date"], archive_item.instagram_post.posted_at.strftime("%FT%T%:z")
 
     assert_not_nil archive_item.instagram_post.author
     assert_not_nil archive_item.instagram_post.images

--- a/test/models/instagram_user_test.rb
+++ b/test/models/instagram_user_test.rb
@@ -4,7 +4,7 @@ class InstagramUserTest < ActiveSupport::TestCase
   def setup
     @zorki_user = InstagramMediaSource.extract(
       "https://www.instagram.com/p/CQDeYPhMJLG/", true
-    ).first["user"]
+    ).first["post"]["user"]
   end
 
   def teardown


### PR DESCRIPTION
This PR updates Zenodotus to comply with Hypatia's new return schema. Posts are nested one level down from where we used to expect them.  

It also corrects a sorbet type mistake. All tests should pass once this goes in!

### Testing
`rails t`