### PR TITLE
Fix method signature for Twitter user data export

### DIFF
--- a/app/controllers/twitter_users_controller.rb
+++ b/app/controllers/twitter_users_controller.rb
@@ -8,7 +8,7 @@ class TwitterUsersController < ApplicationController
   end
 
   # Exports all media items created by the currently viewed Twitter user to a JSON file
-  sig { vid }
+  sig { void }
   def export_tweeter_data
     tweet_archive_items = ArchiveItem.includes(archivable_item: [:author])
                                      .where(archivable_item_type: "Sources::Tweet")


### PR DESCRIPTION
The method sig for `TwitterUsersController.export_tweeter_data` had a typo, and consequently the method would throw an error. This PR repairs that.

**To test:**

1. Before pulling this code, run the app and navigate to a Twitter user's page (e.g. a URL rooted at `/twitter_users`) and click on the download arrow next to "Archived Media Items". This should ❌ fail.
2. Pull this code.
3. Do the same thing. Now the download should ✅ succeed.

Closes #161
