### PR TITLE
Fix a bunch of type errors between Hypatia

### DIFF
--- a/app/controllers/archive_controller.rb
+++ b/app/controllers/archive_controller.rb
@@ -87,7 +87,12 @@ class ArchiveController < ApplicationController
   # When a scrape is over the scraper will call this
   sig { void }
   def scrape_result_callback
-    parsed_params = JSON.parse(request.raw_post)
+    begin
+      parsed_params = JSON.parse(request.raw_post)
+    rescue JSON::ParserError
+      parsed_params = {}
+    end
+
     render json: { error: "Missing scrape id" }, status: 404 and return unless parsed_params.has_key?("scrape_id")
 
     # Validate id for auth purposes (auth key too?)

--- a/app/jobs/scraper_job.rb
+++ b/app/jobs/scraper_job.rb
@@ -24,8 +24,11 @@ class ScraperJob < ApplicationJob
 
   def perform(media_source_class, media_model, url, user)
     puts "Beginning to scrape #{url} @ #{Time.now}"
-    media_source_class.extract(url)
-    # media_model.create_from_hash(media_item, user)
+    media_item = media_source_class.extract(url)
+
+    # If a scraper runs locally we can't create the actual model from the callback, so we do it now
+    media_model.create_from_hash(media_item, user) if media_source_class.runs_scraper_locally?
+
     puts "Done scraping #{url} @ #{Time.now}"
   end
 

--- a/app/media_sources/facebook_media_source.rb
+++ b/app/media_sources/facebook_media_source.rb
@@ -18,10 +18,11 @@ class FacebookMediaSource < MediaSource
   # @params force [Boolean] force Hypatia to not queue a request but to scrape immediately.
   #   Default: false
   # @returns [String or nil] the path of the screenshot if the screenshot was saved
-  sig { override.params(url: String, force: T::Boolean).returns(T::Array[String]) }
+  sig { override.params(url: String, force: T::Boolean).returns(T.any(T::Boolean, T::Array[Hash])) }
   def self.extract(url, force = false)
     object = self.new(url)
     return object.retrieve_facebook_post! if force
+
     object.retrieve_facebook_post
   end
 
@@ -85,7 +86,7 @@ class FacebookMediaSource < MediaSource
   def retrieve_facebook_post!
     scrape = Scrape.create!({ url: @url, scrape_type: :instagram })
 
-    params = { auth_key: Figaro.env.ZORKI_AUTH_KEY, url: @url, callback_id: scrape.id }
+    params = { auth_key: Figaro.env.ZORKI_AUTH_KEY, url: @url, callback_id: scrape.id, force: true }
     params[:callback_url] = Figaro.env.URL unless Figaro.env.URL.blank?
 
     response = Typhoeus.get(
@@ -95,7 +96,6 @@ class FacebookMediaSource < MediaSource
     )
 
     raise ExternalServerError, "Error: #{response.code} returned from external Forki server" unless response.code == 200
-
     JSON.parse(response.body)
   end
 end

--- a/app/media_sources/media_source.rb
+++ b/app/media_sources/media_source.rb
@@ -39,6 +39,17 @@ class MediaSource
     raise MediaSource::HostError.new(url, self)
   end
 
+  # This is a flag if the scraper is run by Hypatia or locally, mostly so the ScraperJob can know
+  # Default is false if not implemented
+  #
+  # @!scope class
+  # @return [Boolean] true if the scraper is run locally.
+  #   Raises an error if it's invalid.
+  sig { returns(T::Boolean) }
+  def self.runs_scraper_locally?
+    false
+  end
+
   # A error to indicate the host of a given url does not pass validation
   class HostError < StandardError
     extend T::Sig

--- a/app/media_sources/twitter_media_source.rb
+++ b/app/media_sources/twitter_media_source.rb
@@ -11,6 +11,17 @@ class TwitterMediaSource < MediaSource
     ["www.twitter.com", "twitter.com"]
   end
 
+  # This is a flag if the scraper is run by Hypatia or locally, mostly so the ScraperJob can know
+  # Default is false if not implemented
+  #
+  # @!scope class
+  # @return [Boolean] true if the scraper is run locally.
+  #   Raises an error if it's invalid.
+  sig { returns(T::Boolean) }
+  def self.runs_scraper_locally?
+    true
+  end
+
   # Capture a screenshot of the given url
   #
   # @!scope class
@@ -46,8 +57,7 @@ class TwitterMediaSource < MediaSource
   sig { returns(T::Array[Birdsong::Tweet]) }
   def retrieve_tweet
     id = TwitterMediaSource.extract_tweet_id_from_url(@url)
-    response = Birdsong::Tweet.lookup(id)
-    Sources::Tweet.create_from_birdsong_hash(response)
+    Birdsong::Tweet.lookup(id)
   end
 
 private

--- a/app/media_sources/twitter_media_source.rb
+++ b/app/media_sources/twitter_media_source.rb
@@ -46,7 +46,8 @@ class TwitterMediaSource < MediaSource
   sig { returns(T::Array[Birdsong::Tweet]) }
   def retrieve_tweet
     id = TwitterMediaSource.extract_tweet_id_from_url(@url)
-    Birdsong::Tweet.lookup(id)
+    response = Birdsong::Tweet.lookup(id)
+    Sources::Tweet.create_from_birdsong_hash(response)
   end
 
 private

--- a/app/models/sources/facebook_post.rb
+++ b/app/models/sources/facebook_post.rb
@@ -76,7 +76,6 @@ class Sources::FacebookPost < ApplicationRecord
   sig { params(forki_posts: T::Array[Hash], user: T.nilable(User)).returns(T::Array[ArchiveItem]) }
   def self.create_from_forki_hash(forki_posts, user = nil)
     forki_posts.map do |forki_post|
-      forki_post = JSON.parse(forki_post).first
       forki_post = forki_post["post"]
       facebook_user = Sources::FacebookUser.create_from_forki_hash([forki_post["user"]]).first.facebook_user
 

--- a/app/models/sources/instagram_post.rb
+++ b/app/models/sources/instagram_post.rb
@@ -81,7 +81,6 @@ class Sources::InstagramPost < ApplicationRecord
   sig { params(zorki_posts: T::Array[Hash], user: T.nilable(User)).returns(T::Array[ArchiveItem]) }
   def self.create_from_zorki_hash(zorki_posts, user = nil)
     zorki_posts.map do |zorki_post|
-      zorki_post = JSON.parse(zorki_post).first
       zorki_post = zorki_post["post"]
       user_json = zorki_post["user"]
       instagram_user = Sources::InstagramUser.create_from_zorki_hash([user_json]).first.instagram_user

--- a/test/controllers/archive_controller_test.rb
+++ b/test/controllers/archive_controller_test.rb
@@ -38,7 +38,7 @@ class ArchiveControllerTest < ActionDispatch::IntegrationTest
     # make a forced scrape call to Hypatia, then create it from there
     forced_scrape_result = InstagramMediaSource.extract("https://www.instagram.com/p/CBcqOkyDDH8/?utm_source=ig_embed", true)
     scrape = Scrape.create!({ url: "https://www.instagram.com/p/CBcqOkyDDH8/?utm_source=ig_embed", scrape_type: :instagram })
-    callback_response_json = { scrape_id: scrape.id, scrape_result: forced_scrape_result }
+    callback_response_json = { scrape_id: scrape.id, scrape_result: forced_scrape_result.first }
     post scrape_result_callback_url, as: :json, params: callback_response_json
     assert_response :success
 

--- a/test/models/tweet_test.rb
+++ b/test/models/tweet_test.rb
@@ -4,8 +4,8 @@ require "test_helper"
 class TweetTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
   def setup
-    # @birdsong_tweet = TwitterMediaSource.extract("https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
-    # @birdsong_tweet2 = TwitterMediaSource.extract("https://twitter.com/AmtrakNECAlerts/status/1400055826170191874")
+    @birdsong_tweet = TwitterMediaSource.extract("https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
+    @birdsong_tweet2 = TwitterMediaSource.extract("https://twitter.com/AmtrakNECAlerts/status/1400055826170191874")
   end
 
   def teardown

--- a/test/models/tweet_test.rb
+++ b/test/models/tweet_test.rb
@@ -4,8 +4,8 @@ require "test_helper"
 class TweetTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
   def setup
-    @birdsong_tweet = TwitterMediaSource.extract("https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
-    @birdsong_tweet2 = TwitterMediaSource.extract("https://twitter.com/AmtrakNECAlerts/status/1400055826170191874")
+    # @birdsong_tweet = TwitterMediaSource.extract("https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
+    # @birdsong_tweet2 = TwitterMediaSource.extract("https://twitter.com/AmtrakNECAlerts/status/1400055826170191874")
   end
 
   def teardown
@@ -41,8 +41,8 @@ class TweetTest < ActiveSupport::TestCase
     Sources::Tweet.create_from_url!("https://twitter.com/Citruscrush/status/1094999286281048070?fbclid=IwAR20aObVHvlSdu-e2L2mTHXytMqgoGvH6tur4vLz0bU4E2p5k4NciEOAgiE")
     perform_enqueued_jobs
 
-    tweet_1 = Sources::Tweet.where(twitter_id: 1397922363551870990).first
-    tweet_2 = Sources::Tweet.where(twitter_id: 1094999286281048070).first
+    tweet_1 = Sources::Tweet.where(twitter_id: "1397922363551870990").first
+    tweet_2 = Sources::Tweet.where(twitter_id: "1094999286281048070").first
 
     assert_not_nil tweet_1
     assert_not_nil tweet_2


### PR DESCRIPTION
This fixes a few little bugs that caused some broken tests when scraping
primarily facebook and twitter. Why this happened when we though we had
fixed it awhile ago? Unsure.

However, all tests should fully pass after this.

To test:
`rails t`