### PR TITLE
Fix type issue when extracting from facebook

### DIFF
--- a/app/media_sources/facebook_media_source.rb
+++ b/app/media_sources/facebook_media_source.rb
@@ -57,7 +57,7 @@ class FacebookMediaSource < MediaSource
   # @!visibility private
   # @params url [String] a url to grab data for
   # @return [Forki::Post]
-  sig { returns(T::Array[Hash]) }
+  sig { returns(T::Boolean) }
   def retrieve_facebook_post
     scrape = Scrape.create!({ url: @url, scrape_type: :facebook })
 
@@ -82,7 +82,7 @@ class FacebookMediaSource < MediaSource
   # Scrape the page by sending it to Hypatia and forcing the server to process the job immediately. Should only be used for tests
   #
   # @return [Hash]
-  sig { returns(Array) }
+  sig { returns(T::Array[Hash]) }
   def retrieve_facebook_post!
     scrape = Scrape.create!({ url: @url, scrape_type: :instagram })
 

--- a/test/media_sources/facebook_media_source_test.rb
+++ b/test/media_sources/facebook_media_source_test.rb
@@ -19,4 +19,9 @@ class FacebookMediaSourceTest < ActiveSupport::TestCase
     facebook_post_hash = FacebookMediaSource.extract("https://www.facebook.com/381726605193429/photos/a.764764956889590/3625268454172545/", true)
     assert_not facebook_post_hash.empty?
   end
+
+  def test_extracting_returns_true_without_force
+    result = FacebookMediaSource.extract("https://www.facebook.com/381726605193429/photos/a.764764956889590/3625268454172545/")
+    assert result
+  end
 end


### PR DESCRIPTION
When not forcing a request to a `FacebookMediaSource` we had a bug in
the typing that would mean it would always error out. Whoops. There
didn't seem to be a test for this either. I've fixed both.

To test
`rails t test/media_sources/facebook_media_source_test.rb`