### PR TITLE
Prefix Active Job queues with Zenodotus namespace

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,5 +68,8 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
+  # Prefix job queues names to avoid collisions
+  config.active_job.queue_name_prefix = "zenodotus_development"
+
   config.hosts << "showoff-reporterslab.pagekite.me"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "zenodotus_production"
+  config.active_job.queue_name_prefix = "zenodotus_production"
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Prefix job queues names to avoid collisions
+  config.active_job.queue_name_prefix = "zenodotus_test"
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,10 +1,16 @@
 development:
   :concurrency: 5
+  :queues:
+    - [zenodotus_development_urgent, 2]
+    - zenodotus_development_default
+test:
+  :queues:
+    - [zenodotus_test_urgent, 2]
+    - zenodotus_test_default
 production:
   :concurrency: 6
-:queues:
-  - [urgent, 2]
-  - default
-
+  :queues:
+    - [zenodotus_production_urgent, 2]
+    - zenodotus_production_default
 :verbose: true
 :timeout: 8


### PR DESCRIPTION
This PR prefixes Active Job queue names with `zenodotus_{environment}` to avoid queue collisions when Zenodotus is being run on the same machine as another Sidekiq-using app (like Hypatia locally).

To test:
- [ ] Clean `rails test` (except the existing test failure on `master`)
- [ ] Run the app and make sure archiving URLs still works
- [ ] Bonus points for doing the above while also running Hypatia

🚨 Pay particular attention to the fact that I enabled prefixes in production, too. You may not want this! But I figured, hey, why not.

Closes #171