### PR TITLE
Condense environment variable list

### DIFF
--- a/app/media_sources/facebook_media_source.rb
+++ b/app/media_sources/facebook_media_source.rb
@@ -61,16 +61,16 @@ class FacebookMediaSource < MediaSource
   def retrieve_facebook_post
     scrape = Scrape.create!({ url: @url, scrape_type: :facebook })
 
-    params = { auth_key: Figaro.env.ZORKI_AUTH_KEY, url: @url, callback_id: scrape.id }
+    params = { auth_key: Figaro.env.HYPATIA_AUTH_KEY, url: @url, callback_id: scrape.id }
     params[:callback_url] = Figaro.env.URL unless Figaro.env.URL.blank?
 
     response = Typhoeus.get(
-      Figaro.env.ZORKI_SERVER_URL,
+      Figaro.env.HYPATIA_SERVER_URL,
       followlocation: true,
       params: params
     )
 
-    raise ExternalServerError, "Error: #{response.code} returned from external Zorki server" unless response.code == 200
+    raise ExternalServerError, "Error: #{response.code} returned from Hypatia server" unless response.code == 200
     response_body = JSON.parse(response.body)
     # _ = JSON.parse(response.body)
     # TODO:  Parse response body properly and check for errors
@@ -86,16 +86,16 @@ class FacebookMediaSource < MediaSource
   def retrieve_facebook_post!
     scrape = Scrape.create!({ url: @url, scrape_type: :instagram })
 
-    params = { auth_key: Figaro.env.ZORKI_AUTH_KEY, url: @url, callback_id: scrape.id, force: true }
+    params = { auth_key: Figaro.env.HYPATIA_AUTH_KEY, url: @url, callback_id: scrape.id, force: true }
     params[:callback_url] = Figaro.env.URL unless Figaro.env.URL.blank?
 
     response = Typhoeus.get(
-      Figaro.env.ZORKI_SERVER_URL,
+      Figaro.env.HYPATIA_SERVER_URL,
       followlocation: true,
       params: params
     )
 
-    raise ExternalServerError, "Error: #{response.code} returned from external Forki server" unless response.code == 200
+    raise ExternalServerError, "Error: #{response.code} returned from Hypatia server" unless response.code == 200
     returned_data = JSON.parse(response.body)
     returned_data["scrape_result"] = JSON.parse(returned_data["scrape_result"])
     returned_data

--- a/app/media_sources/instagram_media_source.rb
+++ b/app/media_sources/instagram_media_source.rb
@@ -49,16 +49,16 @@ class InstagramMediaSource < MediaSource
   def retrieve_instagram_post
     scrape = Scrape.create!({ url: @url, scrape_type: :instagram })
 
-    params = { auth_key: Figaro.env.ZORKI_AUTH_KEY, url: @url, callback_id: scrape.id }
+    params = { auth_key: Figaro.env.HYPATIA_AUTH_KEY, url: @url, callback_id: scrape.id }
     params[:callback_url] = Figaro.env.URL unless Figaro.env.URL.blank?
 
     response = Typhoeus.get(
-      Figaro.env.ZORKI_SERVER_URL,
+      Figaro.env.HYPATIA_SERVER_URL,
       followlocation: true,
       params: params
     )
 
-    raise ExternalServerError, "Error: #{response.code} returned from external Zorki server" unless response.code == 200
+    raise ExternalServerError, "Error: #{response.code} returned from Hypatia server" unless response.code == 200
     response_body = JSON.parse(response.body)
     # _ = JSON.parse(response.body)
     # TODO:  Parse response body properly and check for errors
@@ -73,16 +73,16 @@ class InstagramMediaSource < MediaSource
   def retrieve_instagram_post!
     scrape = Scrape.create!({ url: @url, scrape_type: :instagram })
 
-    params = { auth_key: Figaro.env.ZORKI_AUTH_KEY, url: @url, callback_id: scrape.id, force: "true" }
+    params = { auth_key: Figaro.env.HYPATIA_AUTH_KEY, url: @url, callback_id: scrape.id, force: "true" }
     params[:callback_url] = Figaro.env.URL unless Figaro.env.URL.blank?
 
     response = Typhoeus.get(
-      Figaro.env.ZORKI_SERVER_URL,
+      Figaro.env.HYPATIA_SERVER_URL,
       followlocation: true,
       params: params
     )
 
-    raise ExternalServerError, "Error: #{response.code} returned from external Zorki server" unless response.code == 200
+    raise ExternalServerError, "Error: #{response.code} returned from Hypatia server" unless response.code == 200
 
     # Hypatia returns arrays always so we grab the first
     returned_data = JSON.parse(response.body)

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -4,13 +4,16 @@ Figaro.require_keys("TWITTER_BEARER_TOKEN")
 # `rails secret`
 Figaro.require_keys("KEY_ENCRYPTION_SALT")
 
-# The URL and auth key for the external Zorki gem scraper
-Figaro.require_keys("ZORKI_SERVER_URL")
-Figaro.require_keys("ZORKI_AUTH_KEY")
+# The URL and auth key for Hypatia
+Figaro.require_keys("HYPATIA_SERVER_URL")
+Figaro.require_keys("HYPATIA_AUTH_KEY")
+
+# Scraper-specific secrets
+Figaro.require_keys("INSTAGRAM_USER_NAME", "INSTAGRAM_PASSWORD")
+Figaro.require_keys("FACEBOOK_EMAIL", "FACEBOOK_PASSWORD")
+Figaro.require_keys("TWITTER_BEARER_TOKEN")
+Figaro.require_keys("YOUTUBE_API_KEY")
+
 
 # The URL of the currently running server for Hypatia callbacks
 Figaro.require_keys("URL")
-
-# The URL and auth key for the external Forki gem scraper
-# Figaro.require_keys("FORKI_SERVER_URL")
-# Figaro.require_keys("FORKI_AUTH_KEY")

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -8,12 +8,5 @@ Figaro.require_keys("KEY_ENCRYPTION_SALT")
 Figaro.require_keys("HYPATIA_SERVER_URL")
 Figaro.require_keys("HYPATIA_AUTH_KEY")
 
-# Scraper-specific secrets
-Figaro.require_keys("INSTAGRAM_USER_NAME", "INSTAGRAM_PASSWORD")
-Figaro.require_keys("FACEBOOK_EMAIL", "FACEBOOK_PASSWORD")
-Figaro.require_keys("TWITTER_BEARER_TOKEN")
-Figaro.require_keys("YOUTUBE_API_KEY")
-
-
 # The URL of the currently running server for Hypatia callbacks
 Figaro.require_keys("URL")

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,6 +2,20 @@
 
 ## Environment Setup
 
+### Environment variables
+To run Zenodotus, you'll need to set the following environment variables. Ask a dev on the team to provide you access to them. 
+- `INSTAGRAM_USER_NAME`
+- `INSTAGRAM_PASSWORD`
+- `FACEBOOK_EMAIL`
+- `FACEBOOK_PASSWORD`
+- `TWITTER_BEARER_TOKEN`
+- `YOUTUBE_API_KEY`
+- `HYPATIA_SERVER_URL`
+- `HYPATIA_AUTH_KEY`
+- `secret_key_base` (Devise secret)
+- `KEY_ENCRYPTION_SALT`
+- `URL`
+
 ### Linters
 
 We use two linters to insure that all code looks and acts the same. These enforeced styles may be different

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,12 +4,7 @@
 
 ### Environment variables
 To run Zenodotus, you'll need to set the following environment variables. Ask a dev on the team to provide you access to them. 
-- `INSTAGRAM_USER_NAME`
-- `INSTAGRAM_PASSWORD`
-- `FACEBOOK_EMAIL`
-- `FACEBOOK_PASSWORD`
 - `TWITTER_BEARER_TOKEN`
-- `YOUTUBE_API_KEY`
 - `HYPATIA_SERVER_URL`
 - `HYPATIA_AUTH_KEY`
 - `secret_key_base` (Devise secret)


### PR DESCRIPTION
This PR removes the `ZORKI_AUTH_KEY`/`FORKI_AUTH_KEY` and `ZORKI_SERVER_URL`/`FORKI_SERVER_URL` environment variables and replace them with `HYPATIA_AUTH_KEY`/`HYPATIA_SERVER_URL`. 

It also updates `config/intializers/figaro.rb` to require the presence of all of Zenodotus' environment variables. 

Changes are documented in the developer README.

# Testing
- `rails t`

_Note: before testing, make sure you've set all environment variables. Before merging this PR, we may need to create a shared Tech&Check YouTube API key._