### PR TITLE
Implement video hashing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,8 @@ GIT
   specs:
     eikon (0.1.0)
       ruby-vips (~> 2.1)
+      sorbet-runtime (>= 0.5.9204)
+      terrapin (~> 0.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/app/models/archive_item.rb
+++ b/app/models/archive_item.rb
@@ -1,6 +1,8 @@
 # typed: strict
 
 class ArchiveItem < ApplicationRecord
+  include Dhashable
+
   delegated_type :archivable_item, types: %w[Sources::Tweet Sources::InstagramPost Sources::FacebookPost Sources::YoutubePost]
   delegate :service_id, to: :archivable_item
   delegate :images, to: :archivable_item

--- a/app/models/archive_item.rb
+++ b/app/models/archive_item.rb
@@ -7,6 +7,7 @@ class ArchiveItem < ApplicationRecord
   delegate :videos, to: :archivable_item
 
   has_one :media_review, dependent: :destroy, foreign_key: :archive_item_id
+  has_many :image_hashes, dependent: :destroy
   belongs_to :submitter, optional: true, class_name: "User"
   belongs_to :scrape, optional: true
 

--- a/app/models/concerns/dhashable.rb
+++ b/app/models/concerns/dhashable.rb
@@ -1,11 +1,12 @@
 # typed: false
-# require "dhash-vips"
 
 module Dhashable
   extend ActiveSupport::Concern
+  extend T::Sig
 
   included do
-    before_save :generate_dhash
+    before_save :generate_single_dhash
+    after_save :generate_dhashes_for_attached_media
   end
 
   # Returns whether the object is a image attachment type or a video attachment type
@@ -13,36 +14,48 @@ module Dhashable
   # @return a symbol telling which type of attachment this is
   sig { returns(Symbol) }
   def attachment_type
-    return :video unless self.image.nil?
-    return :image unless self.video.nil?
+    return :video if self.archivable_item.respond_to?("video")
+    return :image if self.archivable_item.respond_to?("images")
 
     raise "Unable to determine type of attachment. You shouldn't be seeing this."
   end
 
-  def generate_dhash
-    self.image.open
-    tempfile_path = image.tempfile.path
-    dhashes = nil
+  def generate_dhashes_for_attached_media
+    return unless self.respond_to?(:archivable_item)
 
-    case self.attachment_type
-    when :image
-      dhashes = [Eikon.dhash_for_image(tempfile_path)]
-    when :video
-      dhashes = Eikon.dhash_for_video(tempfile_path)
+    self.archivable_item.images.each do |image|
+      image.image.open
+      tempfile_path = image.image.tempfile.path
+      dhashes = nil
+
+      case self.attachment_type
+      when :image
+        dhashes = [Eikon.dhash_for_image(tempfile_path)]
+      when :video
+        dhashes = Eikon.dhash_for_video(tempfile_path)
+      end
+
+      dhashes.map do |dhash|
+        ImageHash.create!({
+          dhash: dhash,
+          archive_item: self
+        })
+      end
+
+      image.image.close
     end
-
-    dhashes.map do |dhash|
-      ImageHash.create!({
-        dhash: dhash,
-        archive_item: self
-      })
-    end
-
-    self.image.close
-
     ####
     ## NOTE This is where i left it, going to have to write some tests here
     # => Also drop the dhash property of this
     ####
+  end
+
+  def generate_single_dhash
+    return unless self.respond_to?(:dhash)
+
+    self.image.open
+    tempfile_path = self.image.tempfile.path
+    self.dhash = Eikon.dhash_for_image(tempfile_path)
+    # self.image.close
   end
 end

--- a/app/models/concerns/dhashable.rb
+++ b/app/models/concerns/dhashable.rb
@@ -22,6 +22,7 @@ module Dhashable
 
   def generate_dhashes_for_attached_media
     return unless self.respond_to?(:archivable_item)
+    return if self.videos.empty? && self.images.empty? # if the post is just text, for some reason
 
     media_items = attachment_type == :image ? self.archivable_item.images : self.archivable_item.videos
     media_items.each do |media_item|

--- a/app/models/concerns/dhashable.rb
+++ b/app/models/concerns/dhashable.rb
@@ -8,15 +8,41 @@ module Dhashable
     before_save :generate_dhash
   end
 
+  # Returns whether the object is a image attachment type or a video attachment type
+  #
+  # @return a symbol telling which type of attachment this is
+  sig { returns(Symbol) }
+  def attachment_type
+    return :video unless self.image.nil?
+    return :image unless self.video.nil?
+
+    raise "Unable to determine type of attachment. You shouldn't be seeing this."
+  end
+
   def generate_dhash
     self.image.open
     tempfile_path = image.tempfile.path
-    self.dhash = Eikon.dhash_for_file(tempfile_path)
+    dhashes = nil
 
-    # self.dhash = DHashVips::IDHash.fingerprint(tempfile_path, 3)
+    case self.attachment_type
+    when :image
+      dhashes = [Eikon.dhash_for_image(tempfile_path)]
+    when :video
+      dhashes = Eikon.dhash_for_video(tempfile_path)
+    end
 
-    # This is commented out because otherwise it causes an error when uploading it up
-    # Let's hope it doesn't cause memory leaks
-    # self.image.close
+    dhashes.map do |dhash|
+      ImageHash.create!({
+        dhash: dhash,
+        archive_item: self
+      })
+    end
+
+    self.image.close
+
+    ####
+    ## NOTE This is where i left it, going to have to write some tests here
+    # => Also drop the dhash property of this
+    ####
   end
 end

--- a/app/models/image_hash.rb
+++ b/app/models/image_hash.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+class ImageHash < ApplicationRecord
+  belongs_to :archive_item
+end

--- a/app/models/image_search.rb
+++ b/app/models/image_search.rb
@@ -18,9 +18,9 @@ class ImageSearch < ApplicationRecord
     images = ArchiveItem.all.filter_map do |archive_item|
       # Right now we're only doing images, and only one at the moment. We'll expand that later though
       next if archive_item.images.empty?
-      image = archive_item.images.first
+      image_hash = archive_item.image_hashes.first
 
-      dhash_score = Eikon::Comparator.compare(self.dhash, image.dhash)
+      dhash_score = Eikon::Comparator.compare(self.dhash, image_hash.dhash)
       # dhash = DHashVips::IDHash.distance3 self.dhash.to_i, image.dhash.to_i
       { image: image, score: dhash_score }
     end

--- a/app/models/image_search.rb
+++ b/app/models/image_search.rb
@@ -21,7 +21,6 @@ class ImageSearch < ApplicationRecord
       image_hash = archive_item.image_hashes.first
 
       dhash_score = Eikon::Comparator.compare(self.dhash, image_hash.dhash)
-      # dhash = DHashVips::IDHash.distance3 self.dhash.to_i, image.dhash.to_i
       { image: image, score: dhash_score }
     end
 

--- a/app/models/media_models/images/facebook_image.rb
+++ b/app/models/media_models/images/facebook_image.rb
@@ -2,7 +2,6 @@
 
 class MediaModels::Images::FacebookImage < ApplicationRecord
   include ImageUploader::Attachment(:image)
-  include Dhashable
 
   # Optional is marked true here because the image is technically saved before
   # it's added to the model itself.

--- a/app/models/media_models/images/instagram_image.rb
+++ b/app/models/media_models/images/instagram_image.rb
@@ -2,7 +2,6 @@
 
 class MediaModels::Images::InstagramImage < ApplicationRecord
   include ImageUploader::Attachment(:image)
-  include Dhashable
 
   # Optional is marked true here because the image is technically saved before
   # it's added to the model itself.

--- a/app/models/media_models/images/twitter_image.rb
+++ b/app/models/media_models/images/twitter_image.rb
@@ -2,7 +2,6 @@
 
 class MediaModels::Images::TwitterImage < ApplicationRecord
   include ImageUploader::Attachment(:image)
-  include Dhashable
 
   # Optional is marked true here because the image is technically saved before
   # it's added to the model itself.

--- a/db/migrate/20220420175054_create_image_hashes.rb
+++ b/db/migrate/20220420175054_create_image_hashes.rb
@@ -1,0 +1,9 @@
+class CreateImageHashes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :image_hashes, id: :uuid do |t|
+      t.string :dhash, required: true
+      t.uuid :archive_item_id, required: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220422194316_drop_dhash_from_image_models.rb
+++ b/db/migrate/20220422194316_drop_dhash_from_image_models.rb
@@ -1,0 +1,7 @@
+class DropDhashFromImageModels < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :instagram_images, :dhash
+    remove_column :twitter_images, :dhash
+    remove_column :facebook_images, :dhash
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_31_162925) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_20_175054) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -91,6 +91,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_31_162925) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["facebook_post_id"], name: "index_facebook_videos_on_facebook_post_id"
+  end
+
+  create_table "image_hashes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "dhash"
+    t.uuid "archive_item_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "image_searches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_20_175054) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_22_194316) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -50,14 +50,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_20_175054) do
   create_table "facebook_images", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "facebook_post_id"
     t.jsonb "image_data"
-    t.string "dhash"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["facebook_post_id"], name: "index_facebook_images_on_facebook_post_id"
   end
 
   create_table "facebook_posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "posted_at", precision: nil
+    t.datetime "posted_at"
     t.text "text"
     t.text "facebook_id"
     t.uuid "author_id", null: false
@@ -114,14 +113,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_20_175054) do
     t.jsonb "image_data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "dhash"
     t.index ["instagram_post_id"], name: "index_instagram_images_on_instagram_post_id"
   end
 
   create_table "instagram_posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "text", null: false
     t.string "instagram_id", null: false
-    t.datetime "posted_at", precision: nil, null: false
+    t.datetime "posted_at", null: false
     t.integer "number_of_likes", null: false
     t.uuid "author_id", null: false
     t.datetime "created_at", null: false
@@ -203,7 +201,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_20_175054) do
     t.string "twitter_id", null: false
     t.string "language", null: false
     t.uuid "author_id", null: false
-    t.datetime "posted_at", precision: nil, null: false
+    t.datetime "posted_at", null: false
     t.index ["author_id"], name: "index_tweets_on_author_id"
   end
 
@@ -212,14 +210,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_20_175054) do
     t.jsonb "image_data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "dhash"
     t.index ["tweet_id"], name: "index_twitter_images_on_tweet_id"
   end
 
   create_table "twitter_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "handle", null: false
     t.string "display_name", null: false
-    t.datetime "sign_up_date", precision: nil, null: false
+    t.datetime "sign_up_date", null: false
     t.string "twitter_id", null: false
     t.text "description", null: false
     t.string "url", null: false
@@ -245,20 +242,20 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_20_175054) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: nil
-    t.datetime "remember_created_at", precision: nil
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at", precision: nil
-    t.datetime "last_sign_in_at", precision: nil
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.string "confirmation_token"
-    t.datetime "confirmed_at", precision: nil
-    t.datetime "confirmation_sent_at", precision: nil
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
-    t.datetime "locked_at", precision: nil
+    t.datetime "locked_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "approved", default: false, null: false

--- a/test/fixtures/image_hashes.yml
+++ b/test/fixtures/image_hashes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/facebook_post_test.rb
+++ b/test/models/facebook_post_test.rb
@@ -51,9 +51,14 @@ class FacebookPostTest < ActiveSupport::TestCase
     assert_equal archive_item.author.name, archive_item2.author.name
   end
 
-  test "assert_url_can_be_checked" do
+  test "assert url can be checked" do
     assert Sources::FacebookPost.can_handle_url?("https://www.facebook.com/MarkZuckerberg/videos/123456789/")
     assert_not Sources::FacebookPost.can_handle_url?("https://www.instagram.com/p/notafakeid/")
+  end
+
+  test "assert archive image from facebook post" do
+    archive_item = Sources::FacebookPost.create_from_forki_hash(@@forki_post).first
+    assert_not_empty archive_item.image_hashes
   end
 
   test "can archive video from Facebook post" do
@@ -65,7 +70,7 @@ class FacebookPostTest < ActiveSupport::TestCase
 
   test "dhash properly generated from image" do
     archive_item = Sources::FacebookPost.create_from_forki_hash(@@forki_post).first
-    assert_not_nil archive_item.facebook_post.images.first.dhash
+    assert_not_nil archive_item.image_hashes.first.dhash
   end
 
   test "archiving a video creates a preview screenshot" do

--- a/test/models/image_hash_test.rb
+++ b/test/models/image_hash_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ImageHashTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/instagram_post_test.rb
+++ b/test/models/instagram_post_test.rb
@@ -63,6 +63,11 @@ class InstagramPostTest < ActiveSupport::TestCase
     assert result
   end
 
+  test "assert archive image from Instagram post" do
+    archive_item = Sources::InstagramPost.create_from_zorki_hash(@@zorki_post).first
+    assert_not_empty archive_item.image_hashes
+  end
+
   test "can archive video from Instagram post" do
     archive_item = Sources::InstagramPost.create_from_zorki_hash(@@zorki_instagram_post_video)
     assert_not_nil archive_item
@@ -73,7 +78,7 @@ class InstagramPostTest < ActiveSupport::TestCase
 
   test "dhash properly generated from image" do
     archive_item = Sources::InstagramPost.create_from_zorki_hash(@@zorki_post).first
-    assert_not_nil archive_item.instagram_post.images.first.dhash
+    assert_not_nil archive_item.image_hashes.first.dhash
   end
 
   test "archiving a video creates a preview screenshot" do

--- a/test/models/tweet_test.rb
+++ b/test/models/tweet_test.rb
@@ -4,8 +4,8 @@ require "test_helper"
 class TweetTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
   def setup
-    @birdsong_tweet = TwitterMediaSource.extract("https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
-    @birdsong_tweet2 = TwitterMediaSource.extract("https://twitter.com/AmtrakNECAlerts/status/1400055826170191874")
+    @birdsong_tweet = TwitterMediaSource.extract("https://twitter.com/NYCSanitation/status/1517229098795515906?s=20&t=MJ1KtW5vuzW6Pxs5IJGdDw")
+    @birdsong_tweet2 = TwitterMediaSource.extract("https://twitter.com/NYCSanitation/status/1517093299298963456?s=20&t=MJ1KtW5vuzW6Pxs5IJGdDw")
   end
 
   def teardown
@@ -60,6 +60,11 @@ class TweetTest < ActiveSupport::TestCase
     assert_not Sources::Tweet.can_handle_url?("https://twitter.com/AmtrakNECAlerts/status")
   end
 
+  test "assert archive image from tweet" do
+    archive_item = Sources::Tweet.create_from_birdsong_hash(@birdsong_tweet).first
+    assert_not_empty archive_item.image_hashes
+  end
+
   test "can archive video from tweet" do
     birdsong_tweet_video = TwitterMediaSource.extract("https://twitter.com/JoeBiden/status/1258817692448051200")
     archive_item = Sources::Tweet.create_from_birdsong_hash(birdsong_tweet_video).first
@@ -71,7 +76,7 @@ class TweetTest < ActiveSupport::TestCase
   test "dhash properly generated from image" do
     birdsong_image_tweet = TwitterMediaSource.extract("https://twitter.com/Bucks/status/1412471909296578563")
     archive_item = Sources::Tweet.create_from_birdsong_hash(birdsong_image_tweet).first
-    assert_not_nil archive_item.tweet.images.first.dhash
+    assert_not_nil archive_item.image_hashes.first.dhash
   end
 
   test "archiving a video creates a preview screenshot" do

--- a/test/models/tweet_test.rb
+++ b/test/models/tweet_test.rb
@@ -79,6 +79,15 @@ class TweetTest < ActiveSupport::TestCase
     assert_not_nil archive_item.image_hashes.first.dhash
   end
 
+  test "dhashes properly generated from video" do
+    birdsong_image_tweet = TwitterMediaSource.extract("https://twitter.com/JoeBiden/status/1258817692448051200")
+    archive_item = Sources::Tweet.create_from_birdsong_hash(birdsong_image_tweet).first
+    assert_not archive_item.image_hashes.empty?
+    archive_item.image_hashes.each do |hash|
+      assert_not_nil hash.dhash
+    end
+  end
+
   test "archiving a video creates a preview screenshot" do
     birdsong_tweet_video = TwitterMediaSource.extract("https://twitter.com/JoeBiden/status/1258817692448051200")
     archive_item = Sources::Tweet.create_from_birdsong_hash(birdsong_tweet_video).first


### PR DESCRIPTION
This add hashing of video previews and restructures where hashes live to make it easier to index later on.

On the front end you won't notice anything different, as it's all reflected in data structures.

To test:
bundle install
rails db:migrate
rails t