### PR TITLE
Install Eikon from RubyGems and update to 0.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,8 +115,8 @@ gem "shrine", "~> 3.0"
 # there's been plenty of commits
 # gem "dhash-vips", git: "https://github.com/nakilon/dhash-vips/", tag: "v0.1.1.2"
 
-# gem "eikon", path: "~/Repositories/eikón/eikon"
-gem "eikon", git: "https://github.com/cguess/eikon"
+gem "eikon"
+
 # Stremio-ffmpeg use the ffmpeg library to process our video files
 gem "streamio-ffmpeg"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,13 +23,6 @@ GIT
       oauth (~> 0.5.6)
       typhoeus (~> 1.4.0)
 
-GIT
-  remote: https://github.com/cguess/eikon
-  revision: dd3f886e26a1d0763e75a05fefbb33096d5ce178
-  specs:
-    eikon (0.1.0)
-      ruby-vips (~> 2.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -150,6 +143,10 @@ GEM
       addressable (~> 2.8)
     ecma-re-validator (0.4.0)
       regexp_parser (~> 2.2)
+    eikon (0.1.1)
+      ruby-vips (~> 2.1)
+      sorbet-runtime (>= 0.5.9204)
+      terrapin (~> 0.6.0)
     erubi (1.10.0)
     erubis (2.7.0)
     ethon (0.15.0)
@@ -435,7 +432,7 @@ DEPENDENCIES
   cssbundling-rails
   devise (~> 4.8.0)
   dotenv-rails
-  eikon!
+  eikon
   ferrum (~> 0.11)
   figaro
   forki!


### PR DESCRIPTION
This PR switches our installation of the Eikon gem from @cguess's own repo to RubyGems, and updates it to 0.1.1.

This should resolve the CI failures we've been seeing.