### PR TITLE
Move Tailwind plugins to correct dependency block

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "@hotwired/turbo-rails": "^7.1.0",
     "@rails/actioncable": "^7.0.0",
     "@rails/activestorage": "^7.0.0",
+    "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.5.0",
+    "@tailwindcss/typography": "^0.5.2",
     "autoprefixer": "^10.4.5",
     "esbuild": "^0.14.38",
     "flowbite": "^1.4.3",
@@ -17,8 +19,6 @@
     "tailwindcss": "^3.0.24"
   },
   "devDependencies": {
-    "@tailwindcss/aspect-ratio": "^0.4.0",
-    "@tailwindcss/typography": "^0.5.2",
     "eslint": "^7.22.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-base": "^14.2.1",


### PR DESCRIPTION
I accidentally added two (of our three) Tailwind plugins as dev dependencies, oops. This PR puts them back in the normal dependency stack.

No related issue.