### PR TITLE
Add MIT license to project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright © 2022 Duke Reporters’ Lab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -172,3 +172,7 @@ We use mostly a standard Rails stack, with a few new things that are generally r
 ## Development
 
 See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for additional development setup instructions.
+
+## License
+
+See [LICENSE](./LICENSE) for the terms governing this software.


### PR DESCRIPTION
This PR adds the MIT license to the repo and references it in our README.

**Testing:**
- Fork the project
- Make and sell a commercial version of it
- Convince us to sue you
- Win in court because this license permits that

Closes #199