### PR TITLE
Remove Tailwind safelist hack

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,10 +20,4 @@ module.exports = {
     pluginTailwindTypography,
     pluginFlowbite,
   ],
-  // By default, Tailwind shakes the CSS file down to only those classes that are actually in use.
-  // This makes development a *huge* pain, since if you use any class for the first time, you must
-  // clobber and recompile the base Tailwind stylesheet (since this doesn't happen as eagerly as
-  // changes to your own application styles). This pattern ensures all classes are included when
-  // running in development.
-  safelist: (process.env.NODE_ENV === 'development' ? [{ pattern: /./ }] : []),
 }


### PR DESCRIPTION
This PR removes the `safelist` hack added in bbfdb5b3bc480c19d2bdd2e2a6d8a9f08aac4a92 for reasons explained in the commit message. In summary: I'm no longer seeing the behavior the hack was intended to fix, and it's probably the wrong way to do it anyway.

Not gonna worry about a review on this one, just passing it through PR for history.