### PR TITLE
Repair the retrieve_youtube_post method sig

### DIFF
--- a/app/media_sources/youtube_media_source.rb
+++ b/app/media_sources/youtube_media_source.rb
@@ -52,10 +52,8 @@ class YoutubeMediaSource < MediaSource
 
   # Scrape the page by sending it to Hypatia
   #
-  # @!visibility private
-  # @params url [String] a url to grab data for
-  # @return [YoutubeArchiver::Video]
-  sig { returns(T::Array[Hash]) }
+  # @return [Boolean]
+  sig { returns(T::Boolean) }
   def retrieve_youtube_post
     scrape = Scrape.create!({ url: @url, scrape_type: :youtube })
 

--- a/test/models/youtube_post_test.rb
+++ b/test/models/youtube_post_test.rb
@@ -47,15 +47,15 @@ class YoutubePostTest < ActiveSupport::TestCase
 
 
   test "can archive youtube post from url using ActiveJob" do
-    Sources::YoutubePost.create_from_url!("https://www.youtube.com/watch?v=Df7UtQTFUMQ")
-    Sources::YoutubePost.create_from_url!("https://www.youtube.com/watch?v=kFFvomxcLWo")
+    assert_enqueued_jobs 0
+    assert_performed_jobs 0
+
+    Sources::YoutubePost.create_from_url("https://www.youtube.com/watch?v=Df7UtQTFUMQ")
+    Sources::YoutubePost.create_from_url("https://www.youtube.com/watch?v=kFFvomxcLWo")
+    assert_enqueued_jobs 2
+
     perform_enqueued_jobs
-
-    youtube_post_1 = Sources::YoutubePost.where(youtube_id: "Df7UtQTFUMQ").first
-    youtube_post_2 = Sources::YoutubePost.where(youtube_id: "kFFvomxcLWo").first
-
-    assert_not_nil youtube_post_1
-    assert_not_nil youtube_post_2
+    assert_performed_jobs 2
   end
 
   test "assert url can be checked" do


### PR DESCRIPTION
This PR resolves our ability to scrape YouTube through the queue by fixing the method sig on the `YoutubeMediaSource#retrieve_youtube_post` method. It also updates the test that actually calls this method to be sure we catch it in the future..

**Failing preconditions:**

Before pulling/testing this branch, if you try to run archive a YouTube URL (either through the web interface or through the console using `Sources::YoutubePost.create_from_url "{url}"`, **note the lack of a `!` on the method name**), the scrape would essentially loop indefinitely, so you'd see multiple copies of the scrape until you shut things down.

**Testing:**
- Fire up Zeno app and archive a YouTube URL through the web interface, **or** fire up the Zeno console and archive via `Sources::YoutubePost.create_from_url "https://www.youtube.com/watch?v=Df7UtQTFUMQ"`
- `rails t test/models/youtube_post_test.rb`
- You can also run the entire test suite, but that's all that should be needed

Resolves #211