### PR TITLE
Upgrade Sidekiq to 6.4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "pagy", "~> 5.6"
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 # use sidekiq for job queueing
-gem "sidekiq", "~> 6.3.1"
+gem "sidekiq", "~> 6.4.1"
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 # Use jquery-rails to force confirmation dialogs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,7 +351,7 @@ GEM
     shrine (3.4.0)
       content_disposition (~> 1.0)
       down (~> 5.1)
-    sidekiq (6.3.1)
+    sidekiq (6.4.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
@@ -481,7 +481,7 @@ DEPENDENCIES
   ruby_jard
   selenium-webdriver
   shrine (~> 3.0)
-  sidekiq (~> 6.3.1)
+  sidekiq (~> 6.4.1)
   simplecov
   sorbet
   sorbet-rails


### PR DESCRIPTION
This PR pins us to Sidekiq `~> 6.4.1` (resolving to 6.3.2 currently) in order to get us the fix for very noisy Redis deprecation notices from https://github.com/mperham/sidekiq/pull/5139.

Before this PR, your Sidekiq console is often full of deprecation notices. After this PR, it should be a clean and sparkling place of mostly nothing, like a fancy jacket store.

**To test:**
- 🚨 `bundle install`
- Fire up Sidekiq (of course)
- `rails t`

Closes #176