### PR TITLE
Add S3 downloading for Facebook Posts

### DIFF
--- a/app/controllers/ingest_controller.rb
+++ b/app/controllers/ingest_controller.rb
@@ -173,14 +173,14 @@ class IngestController < ApplicationController
     }
   end
 
-  private
+private
 
-    # Validate MediaReview that was passed in
-    sig { params(media_review: Hash).returns(T::Boolean) }
-    def validate_media_review(media_review)
-      schema = File.open("public/json-schemas/claim-review-schema.json").read
-      JSONSchemer.schema(schema).valid?(media_review)
-    rescue StandardError
-      false
-    end
+  # Validate MediaReview that was passed in
+  sig { params(media_review: Hash).returns(T::Boolean) }
+  def validate_media_review(media_review)
+    schema = File.open("public/json-schemas/claim-review-schema.json").read
+    JSONSchemer.schema(schema).valid?(media_review)
+  rescue StandardError
+    false
+  end
 end

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -12,6 +12,6 @@ Figaro.require_keys("HYPATIA_AUTH_KEY")
 Figaro.require_keys("URL")
 
 if Figaro.env.USE_S3_DEV_TEST == "true" || Rails.env == "production"
-  Figaro.require_keys("AWS_ACCESS_KEY")
-  Figaro.require_keys("AWS_ACCESS_SECRET")
+  Figaro.require_keys("AWS_ACCESS_KEY_ID")
+  Figaro.require_keys("AWS_SECRET_ACCESS_KEY")
 end

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -10,8 +10,8 @@ def make_s3_bucket(bucket_name)
   Shrine::Storage::S3.new(
     bucket: bucket_name, # required
     region: "us-east-1", # required
-    access_key_id: Figaro.env.AWS_ACCESS_KEY,
-    secret_access_key: Figaro.env.AWS_ACCESS_SECRET,
+    access_key_id: Figaro.env.AWS_ACCESS_KEY_ID,
+    secret_access_key: Figaro.env.AWS_SECRET_ACCESS_KEY,
   )
 end
 

--- a/lib/utilities/aws_s3_downloader.rb
+++ b/lib/utilities/aws_s3_downloader.rb
@@ -1,0 +1,43 @@
+# typed: true
+#
+# This helps download files from AWS's S3 (or a compatible API such as CloudFlare's R2)
+# To make this a bit less rough and tumble you have to implement a helper for each different bucket
+# you want to access.
+class AwsS3Downloader
+  extend T::Sig
+  extend T::Helpers
+
+
+  # Download multiple url that was sent from Hypatia
+  sig { params(urls: T::Array[String]).returns(T::Hash[String, String]) }
+  def self.download_files_in_s3_received_from_hypatia(urls)
+    downloads = {}
+    urls.each { |url| downloads[url] = download_from_s3(object_key, bucket_name) }
+    downloads
+  end
+
+  # Download single url that was sent from Hypatia
+  sig { params(url: String).returns(String) }
+  def self.download_file_in_s3_received_from_hypatia(url)
+    bucket_name = Figaro.env.AWS_S3_BUCKET_NAME_HYPATIA
+    object_key = "#{Figaro.env.AWS_S3_PATH_HYPATIA}#{File.basename(url)}"
+
+    download_from_s3(object_key, bucket_name, Rails.root.join("tmp", object_key).to_s)
+  end
+
+private
+
+  # A generic wrapper for downloading from any S3 bucket
+  sig { params(object_key: String, bucket_name: String, local_path: String).returns(String) }
+  def self.download_from_s3(object_key, bucket_name, local_path)
+    s3_client = Aws::S3::Client.new(region: Figaro.env.AWS_REGION)
+
+    s3_client.get_object(
+      response_target: local_path,
+      bucket: bucket_name,
+      key: object_key
+    )
+
+    local_path
+  end
+end


### PR DESCRIPTION
This adds the ability to receive facebook posts that have been uploaded
to s3 instead of sent via Base64

NOTE: This will eventually include other models as well, but it's best to check it now so that I can copy/paste over to the others.

This adds two new AWS settings
```
AWS_S3_PATH_HYPATIA: ""
AWS_S3_BUCKET_NAME_HYPATIA: "zenodotus-testing"
```

For testing you can just copy this code block to `config/application.yml`

NOTE: This changes the old AWS environment variable names as well, please update
them to the new ones outlines in `/config/initializers/fiagro.rb`

To test:
1. Make sure hypatia is set up with master and all the AWS settings are
   correct
1. Insure you've updated your AWS settings, and added the new keys
1. `rails t test/models/facebook_post_test.rb`