### PR TITLE
Redesign user pages

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -21,3 +21,9 @@
 body {
 	line-height: var(--line-height);
 }
+
+body * {
+	transition-property: none;
+	transition-duration: var(--transition-duration);
+	transition-timing-function: var(--transition-timing-function);
+}

--- a/app/assets/stylesheets/archive_items.css
+++ b/app/assets/stylesheets/archive_items.css
@@ -71,7 +71,6 @@ just to examine the template files unless/until we capture it better here.
 	.archive-items--masonry {
 		flex-direction: row;
 		flex-wrap: wrap;
-		justify-content: center;
 	}
 
 	.archive-items--masonry .archive-item {

--- a/app/assets/stylesheets/archive_items.css
+++ b/app/assets/stylesheets/archive_items.css
@@ -154,9 +154,14 @@ may never be widely adopted. If you're reading this in a future when it's been a
 
 .archive-item[data-archive-caption-collapse-mode-value="collapsed"] .archive-item__body-caption-content {
 	--collapsed-lines-of-text: 3;
+
 	overflow: hidden;
 
-	/* For browsers that don't support line clamping: */
+	/*
+	Initially, I intended for this only to apply when line-clamping wasn't supported. However,
+	it seems that line-clamp acts unexpectedly when there are multiple children of the clamped
+	element. So, for now max-height is unversal and all clamping really gets us is the ellipsis.
+	*/
 	max-height: calc(1em * var(--line-height) * var(--collapsed-lines-of-text));
 }
 
@@ -165,7 +170,6 @@ may never be widely adopted. If you're reading this in a future when it's been a
 		display: -webkit-box;
 		-webkit-line-clamp: var(--collapsed-lines-of-text);
 		-webkit-box-orient: vertical;
-		max-height: initial;
 	}
 }
 

--- a/app/assets/stylesheets/archive_items.css
+++ b/app/assets/stylesheets/archive_items.css
@@ -131,7 +131,7 @@ may never be widely adopted. If you're reading this in a future when it's been a
 	row-gap: var(--archive-item--internal-spacing);
 
 	margin-left: var(--archive-item--body-indentation);
-	transition: margin-left var(--transition-timing) var(--transition-function);
+	transition-property: margin-left;
 }
 
 .archive-item[data-publishing-platform="facebook"] .archive-item__body,
@@ -240,7 +240,7 @@ may never be widely adopted. If you're reading this in a future when it's been a
 	font-size: var(--archive-item--metadata-font-size);
 	line-height: var(--archive-item--metadata-line-height);
 
-	transition: margin-left var(--transition-timing) var(--transition-function);
+	transition-property: margin-left;
 }
 
 @media screen and (max-width: 500px) {

--- a/app/assets/stylesheets/author_archives.css
+++ b/app/assets/stylesheets/author_archives.css
@@ -35,7 +35,6 @@ Doesn't include the author's profile info, which is assumed to be separate / a s
 
 	margin: var(--author-archive--header-external-spacing) 0;
 	display: flex;
-	justify-content: space-between;
 	align-items: center;
 	gap: var(--author-archive--header-internal-spacing);
 }
@@ -47,4 +46,8 @@ Doesn't include the author's profile info, which is assumed to be separate / a s
 
 .author-archive__title__archive-size {
 	font-weight: var(--font-weight-bold);
+}
+
+.author-archive__actions {
+	font-size: 0.8rem;
 }

--- a/app/assets/stylesheets/authors.css
+++ b/app/assets/stylesheets/authors.css
@@ -1,14 +1,24 @@
 .author {
 	--author--external-spacing: 5rem;
 	--author--internal-spacing: 1rem;
-	--author--profile-image-gap: 2rem;
-	--author--profile-image-size: 10rem;
-	--author--name-font-size: 2rem;
+	--author--profile-image-gap: 1rem;
+	--author--profile-image-size: 5rem;
+	--author--name-font-size: 1.4rem;
 
 	margin: var(--author--external-spacing) 0;
 	display: flex;
 	align-items: center;
 	gap: var(--author--profile-image-gap);
+
+	transition-property: gap;
+}
+
+@media screen and (min-width: 769px) {
+	.author {
+		--author--profile-image-gap: 2rem;
+		--author--profile-image-size: 10rem;
+		--author--name-font-size: 2rem;
+	}
 }
 
 a.author {
@@ -27,11 +37,14 @@ a.author:hover .author__username {
 	aspect-ratio: 1 / 1;
 	width: var(--author--profile-image-size);
 	height: 100%;
+
+	transition-property: width;
 }
 
 .author__name {
 	font-size: var(--author--name-font-size);
 	line-height: 1.2;
+	transition-property: font-size;
 }
 
 .author__display-name {

--- a/app/assets/stylesheets/buttons.css
+++ b/app/assets/stylesheets/buttons.css
@@ -18,7 +18,7 @@ TODO: This is obviously very minimal at the moment. Will add more styles, variat
 	border-radius: 0.35em;
 	font-weight: var(--font-weight-semibold);
 	text-decoration: none;
-	transition: all var(--transition-timing) var(--transition-function);
+	transition: background-color;
 
 	background-color: #ddd;
 }

--- a/app/assets/stylesheets/variables.css
+++ b/app/assets/stylesheets/variables.css
@@ -18,8 +18,8 @@
 	/*
 	Transitions
 	*/
-	--transition-timing: 200ms;
-	--transition-function: ease;
+	--transition-duration: 200ms;
+	--transition-timing-function: ease;
 
 	/*
 	Typography

--- a/app/controllers/facebook_users_controller.rb
+++ b/app/controllers/facebook_users_controller.rb
@@ -2,6 +2,22 @@ class FacebookUsersController < ApplicationController
   sig { void }
   def show
     @facebook_user = Sources::FacebookUser.find(params[:id])
-    @archive_items = Sources::FacebookPost.where(author_id: @facebook_user.id).includes([:images, :videos])
+    facebook_post_archive_items = ArchiveItem.includes(archivable_item: [:author, :images, :videos])
+                                             .where(archivable_item_type: "Sources::FacebookPost")
+    facebook_posts_by_user = facebook_post_archive_items.select { |t| t.facebook_post.author == @facebook_user }
+    @archive_items = facebook_posts_by_user
+  end
+
+  # Exports all media items created by the currently viewed Facebook user to a JSON file
+  sig { void }
+  def export_facebook_user_data
+    facebook_post_archive_items = ArchiveItem.includes(archivable_item: [:author])
+                                             .where(archivable_item_type: "Sources::FacebookPost")
+    facebook_user = Sources::FacebookUser.find(params[:id])
+    facebook_posts_by_user = facebook_post_archive_items.select { |t| t.facebook_post.author == facebook_user }
+    facebook_post_archive_json = ArchiveItem.prune_archive_items(facebook_posts_by_user)
+    send_data facebook_post_archive_json,
+              type: "application/json; header=present",
+              disposition: "attachment; filename=#{facebook_user.name.parameterize(separator: '_')}_facebook_archive.json"
   end
 end

--- a/app/controllers/instagram_users_controller.rb
+++ b/app/controllers/instagram_users_controller.rb
@@ -3,7 +3,10 @@ class InstagramUsersController < ApplicationController
   sig { void }
   def show
     @instagram_user = Sources::InstagramUser.find(params[:id])
-    @archive_items = Sources::InstagramPost.where(author_id: @instagram_user.id).includes([:images, :videos])
+    instagram_post_archive_items = ArchiveItem.includes(archivable_item: [:author, :images, :videos])
+                                              .where(archivable_item_type: "Sources::InstagramPost")
+    instagram_posts_by_user = instagram_post_archive_items.select { |t| t.instagram_post.author == @instagram_user }
+    @archive_items = instagram_posts_by_user
   end
 
   # Exports all media items created by the currently viewed Instagram user to a JSON file

--- a/app/controllers/twitter_users_controller.rb
+++ b/app/controllers/twitter_users_controller.rb
@@ -4,7 +4,10 @@ class TwitterUsersController < ApplicationController
   sig { void }
   def show
     @twitter_user = Sources::TwitterUser.find(params[:id])
-    @archive_items = Sources::Tweet.where(author_id: @twitter_user.id).includes(%i[images videos])
+    tweet_archive_items = ArchiveItem.includes(archivable_item: [:author, :images, :videos])
+                                     .where(archivable_item_type: "Sources::Tweet")
+    tweets_by_author = tweet_archive_items.select { |t| t.tweet.author == @twitter_user }
+    @archive_items = tweets_by_author
   end
 
   # Exports all media items created by the currently viewed Twitter user to a JSON file

--- a/app/controllers/youtube_channels_controller.rb
+++ b/app/controllers/youtube_channels_controller.rb
@@ -2,6 +2,22 @@ class YoutubeChannelsController < ApplicationController
   sig { void }
   def show
     @youtube_channel = Sources::YoutubeChannel.find(params[:id])
-    @archive_items = Sources::YoutubePost.where(channel_id: @youtube_channel.id).includes([:videos])
+    youtube_post_archive_items = ArchiveItem.includes(archivable_item: [:author, :images, :videos])
+                                            .where(archivable_item_type: "Sources::YoutubePost")
+    youtube_posts_by_channel = youtube_post_archive_items.select { |t| t.youtube_post.author == @youtube_channel }
+    @archive_items = youtube_posts_by_channel
+  end
+
+  # Exports all media items created by the currently viewed YouTube channel to a JSON file
+  sig { void }
+  def export_youtube_channel_data
+    youtube_post_archive_items = ArchiveItem.includes(archivable_item: [:author])
+                                            .where(archivable_item_type: "Sources::YoutubePost")
+    youtube_channel = Sources::YoutubeChannel.find(params[:id])
+    youtube_posts_by_channel = youtube_post_archive_items.select { |t| t.youtube_post.author == youtube_channel }
+    youtube_post_archive_json = ArchiveItem.prune_archive_items(youtube_posts_by_channel)
+    send_data youtube_post_archive_json,
+              type: "application/json; header=present",
+              disposition: "attachment; filename=#{youtube_channel.title.parameterize(separator: '_')}_youtube_archive.json"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,6 +48,9 @@ module ApplicationHelper
 
   # Abbreviates long numbers like 32,348 → 32.3K or 6,325,082 → 6.3M.
   #
+  # The use of `try` on the `delete` method is to protect against values that get passed through
+  # `number_to_human` intact but don't respond to `delete`, such as nil or booleans.
+  #
   # @param number Number The number you want to abbreviated.
   # @returns String The number, abbreviated with its suffix.
   def abbreviate_number(number)
@@ -56,7 +59,7 @@ module ApplicationHelper
       million: "M",
       billion: "B",
       trillion: "T" # Look, I'm optimistic about the size of botnets
-    }).delete(" ")
+    }).try(:delete, " ") || "N/A"
   end
 
   # Generates a list of desired class names (strings) for use in HTML markup.

--- a/app/models/sources/facebook_post.rb
+++ b/app/models/sources/facebook_post.rb
@@ -153,7 +153,7 @@ class Sources::FacebookPost < ApplicationRecord
       author_canonical_path:            url_helpers.facebook_user_path(self.author),
       author_profile_image_url:         self.author.profile_image_url,
       author_display_name:              self.author.name,
-      author_username:                  self.author.profile,
+      author_username:                  nil,
       author_community_count:           self.author.followers_count,
       author_community_noun:            "follower",
       archive_item_self:                self,

--- a/app/views/archive/_archive_item.html.erb
+++ b/app/views/archive/_archive_item.html.erb
@@ -1,4 +1,4 @@
-<% caption_is_collapsable = archive_item_caption.length > 320 %>
+<% caption_is_collapsable = archive_item_caption.present? && archive_item_caption.length > 320 %>
 <% include_author = true unless defined?(include_author) && include_author == false %>
 <%
   archive_item_class_list = generate_class_list_string({

--- a/app/views/facebook_users/show.html.erb
+++ b/app/views/facebook_users/show.html.erb
@@ -1,48 +1,51 @@
-<section class="text-gray-600 body-font">
-  <div class="container px-5 py-24 mx-auto">
-    <div class="flex flex-wrap w-full mb-20">
-      <div class="lg:w-1/2 w-full mb-6 lg:mb-0">
-        <img src="<%= @facebook_user.profile_image_url %>" class="w-40 h-40 mb-5 rounded-full inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
-        <div class="h-1 w-20 bg-pink-200 rounded"></div>
-        <h1 class="sm:text-3xl text-2xl font-medium title-font mb-2 mt-3 text-gray-900"><%= @facebook_user.name %></h1>
-      </div>
-      <div class="lg:w-1/2 w-full leading-relaxed text-gray-500 bg-white border-gray-200 border p-6 rounded-lg">
-        <h3 class="tracking-widest pb-3 text-green-400 text-xs font-medium title-font">Account Details</h3>
-        <ul>
-          <li><span class="text-gray-400">Display Name:</span> <span class="text-lg"><%= @facebook_user.name %></span></li>
-          <li><span class="text-gray-400">Followers:</span> <span class="text-lg"><%= @facebook_user.followers_count %></span></li>
-<!--          <li><span class="text-gray-400">Following:</span> <span class="text-lg"><%#= @facebook_user.like_count %></span></li>-->
-<!--          <br />-->
-          <li><span class="text-gray-400">Description:</span> <span class="text-lg"><%= @facebook_user.profile %></span></li>
-        </ul>
-      </div>
+<div class="author" data-controller="author">
+  <img
+    class="author__image"
+    src="<%= @facebook_user.profile_image_url %>"
+    width="300" height="300"
+    alt="Profile photo of <%= @facebook_user.name %>"
+  >
+  <div class="author__profile">
+    <div class="author__name">
+      <span class="author__display-name"><%= @facebook_user.name %></span>
     </div>
-    <div>
-      <h1 class="text-xl text-green-400 font-medium title-font mb-4">Archived Media Items</h1>
-      <div class="h-1 w-50 bg-pink-200 rounded"></div>
+    <div class="author__metadata">
+      <%= abbreviate_number(@facebook_user.followers_count) %>
+      <%= "follower".pluralize(@facebook_user.followers_count) %>
+      •
+      <%= abbreviate_number(@facebook_user.likes_count) %>
+      <%= "like".pluralize(@facebook_user.likes_count) %>
     </div>
-    <div class="flex flex-wrap-m-4">
-      <% @archive_items.each do |facebook_post| %>
-        <div class="xl:w-1/2 md:w-1 p-4">
-          <div class="bg-white border-gray-200 border p-6 rounded-lg">
-            <h3 class="tracking-widest pb-3 text-green-400 text-xs font-medium title-font">Facebook Posts</h3>
-            <% if facebook_post.images.empty? == false %>
-              <img src="<%= facebook_post.images.first.image_url %>" class="w-40 h-40 mb-5 inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
-            <% elsif facebook_post.videos.empty? == false %>
-              <video
-                width="320"
-                height="240"
-                poster="<%= facebook_post.videos.first.video_derivatives[:preview].url %>"
-                controls>
-                <source src="<%= facebook_post.videos.first.video_url %>" type="video/mp4">
-                Your browser does not support the video tag.
-              </video>
-            <% end %>
-            <p class="leading-relaxed pb-3 text-base"><%= facebook_post.text %></p>
-            <h3 class="text-lg text-gray-900 font-medium title-font mb-4"><%= facebook_post.posted_at %></h3>
-          </div>
-        </div>
+    <div class="author__description">
+      <%= @facebook_user.profile %>
+    </div>
+  </div>
+</div>
+
+<div class="author-archive">
+  <div class="author-archive__header">
+    <h2 class="author-archive__title">
+      <span class="author-archive__title__archive-size"><%= @archive_items.length %></span>
+      <%= "item".pluralize(@archive_items.length) %>
+      archived
+    </h2>
+    <div class="author-archive__actions">
+      <%= link_to facebook_user_download_path, {
+        title: "Download user archive in JSON format",
+        class: "btn icon-prefixed",
+        download: true
+      } do %>
+        <svg class="icon icon--lg"><use xlink:href="#svg-download-outline"></use></svg>
+        JSON
       <% end %>
     </div>
   </div>
-</section>
+  <div class="archive-items archive-items--masonry archive-items--boxed-items">
+    <% @archive_items.each do |archive_item| %>
+      <%= render partial: "archive/archive_item", locals: {
+        **archive_item.normalized_attrs_for_views,
+        include_author: false
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/instagram_users/show.html.erb
+++ b/app/views/instagram_users/show.html.erb
@@ -1,52 +1,52 @@
-<section class="text-gray-600 body-font">
-  <div class="container px-5 py-24 mx-auto">
-    <div class="flex flex-wrap w-full mb-20">
-      <div class="lg:w-1/2 w-full mb-6 lg:mb-0">
-        <img src="<%= @instagram_user.profile_image_url %>" class="w-40 h-40 mb-5 rounded-full inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
-        <div class="h-1 w-20 bg-pink-200 rounded"></div>
-        <h1 class="sm:text-3xl text-2xl font-medium title-font mb-2 mt-3 text-gray-900">@<%= @instagram_user.handle %></h1>
-      </div>
-      <div class="lg:w-1/2 w-full leading-relaxed text-gray-500 bg-white border-gray-200 border p-6 rounded-lg">
-        <h3 class="tracking-widest pb-3 text-green-400 text-xs font-medium title-font">Account Details</h3>
-        <ul>
-          <li><span class="text-gray-400">Display Name:</span> <span class="text-lg"><%= @instagram_user.display_name %></span></li>
-          <li><span class="text-gray-400">Followers:</span> <span class="text-lg"><%= @instagram_user.followers_count %></span></li>
-          <li><span class="text-gray-400">Following:</span> <span class="text-lg"><%= @instagram_user.following_count %></span></li>
-          <br />
-          <li><span class="text-gray-400">Description:</span> <span class="text-lg"><%= @instagram_user.profile %></span></li>
-        </ul>
-      </div>
+<div class="author" data-controller="author">
+  <img
+    class="author__image"
+    src="<%= @instagram_user.profile_image_url %>"
+    width="300" height="300"
+    alt="Profile photo of <%= @instagram_user.display_name %>"
+  >
+  <div class="author__profile">
+    <div class="author__name">
+      <span class="author__display-name"><%= @instagram_user.display_name %></span>
+      <span class="author__username">@<%= @instagram_user.handle %></span>
     </div>
-    <div class="flex">
-      <h1 class="text-xl text-green-400 font-medium title-font mb-4">Archived Media Items</h1>
-      <a class="px-2" href="#">
-        <%= link_to instagram_user_download_path do %>
-          <span class="text-xl font-medium title-font mb-4">↓</span>
-        <% end %>
-      </a>
+    <div class="author__metadata">
+      <%= abbreviate_number(@instagram_user.followers_count) %>
+      <%= "follower".pluralize(@instagram_user.followers_count) %>
+      •
+      <%= abbreviate_number(@instagram_user.following_count) %>
+      following
     </div>
-    <div class="flex flex-wrap-m-4">
-      <% @archive_items.each do |instagram_post| %>
-      <div class="xl:w-1/2 md:w-1 p-4">
-        <div class="bg-white border-gray-200 border p-6 rounded-lg">
-          <h3 class="tracking-widest pb-3 text-green-400 text-xs font-medium title-font">Instagram Posts</h3>
-          <% if instagram_post.images.empty? == false %>
-          <img src="<%= instagram_post.images.first.image_url %>" class="w-40 h-40 mb-5 inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
-          <% elsif instagram_post.videos.empty? == false %>
-          <video
-            width="320"
-            height="240"
-            poster="<%= instagram_post.videos.first.video_derivatives[:preview].url %>"
-            controls>
-            <source src="<%= instagram_post.videos.first.video_url %>" type="video/mp4">
-            Your browser does not support the video tag.
-          </video>
-          <% end %>
-          <p class="leading-relaxed pb-3 text-base"><%= instagram_post.text %></p>
-          <h3 class="text-lg text-gray-900 font-medium title-font mb-4"><%= instagram_post.posted_at %></h3>
-        </div>
-      </div>
+    <div class="author__description">
+      <%= @instagram_user.profile %>
+    </div>
+  </div>
+</div>
+
+<div class="author-archive">
+  <div class="author-archive__header">
+    <h2 class="author-archive__title">
+      <span class="author-archive__title__archive-size"><%= @archive_items.length %></span>
+      <%= "item".pluralize(@archive_items.length) %>
+      archived
+    </h2>
+    <div class="author-archive__actions">
+      <%= link_to instagram_user_download_path, {
+        title: "Download user archive in JSON format",
+        class: "btn icon-prefixed",
+        download: true
+      } do %>
+        <svg class="icon icon--lg"><use xlink:href="#svg-download-outline"></use></svg>
+        JSON
       <% end %>
     </div>
   </div>
-</section>
+  <div class="archive-items archive-items--masonry archive-items--boxed-items">
+    <% @archive_items.each do |archive_item| %>
+      <%= render partial: "archive/archive_item", locals: {
+        **archive_item.normalized_attrs_for_views,
+        include_author: false
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/twitter_users/show.html.erb
+++ b/app/views/twitter_users/show.html.erb
@@ -1,55 +1,67 @@
-<section class="text-gray-600 body-font">
-  <div class="container px-5 py-24 mx-auto">
-    <div class="flex flex-wrap w-full mb-20">
-      <div class="lg:w-1/2 w-full mb-6 lg:mb-0">
-        <img src="<%= @twitter_user.profile_image_url %>" class="w-40 h-40 mb-5 rounded-full inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
-        <div class="h-1 w-20 bg-pink-200 rounded"></div>
-        <h1 class="sm:text-3xl text-2xl font-medium title-font mb-2 mt-3 text-gray-900">@<%= @twitter_user.handle %></h1>
-      </div>
-      <div class="lg:w-1/2 w-full leading-relaxed text-gray-500 bg-white border-gray-200 border p-6 rounded-lg">
-        <h3 class="tracking-widest pb-3 text-green-400 text-xs font-medium title-font">Account Details</h3>
-        <ul>
-          <li><span class="text-gray-400">Display Name:</span> <span class="text-lg"><%= @twitter_user.display_name %></span></li>
-          <li><span class="text-gray-400">Followers:</span> <span class="text-lg"><%= @twitter_user.followers_count %></span></li>
-          <li><span class="text-gray-400">Following:</span> <span class="text-lg"><%= @twitter_user.following_count %></span></li>
-          <li><span class="text-gray-400">Sign Up Date:</span> <span class="text-lg"><%= @twitter_user.sign_up_date %></span></li>
-          <li><span class="text-gray-400">Location:</span> <span class="text-lg"><%= @twitter_user.location %></span></li>
-          <br />
-          <li><span class="text-gray-400">Description:</span> <span class="text-lg"><%= @twitter_user.description %></span></li>
-        </ul>
-      </div>
+<div class="author" data-controller="author">
+  <img
+    class="author__image"
+    src="<%= @twitter_user.profile_image_url %>"
+    width="300" height="300"
+    alt="Profile photo of <%= @twitter_user.display_name %>"
+  >
+  <div class="author__profile">
+    <div class="author__name">
+      <span class="author__display-name"><%= @twitter_user.display_name %></span>
+      <span class="author__username">@<%= @twitter_user.handle %></span>
     </div>
-    <div class="flex">
-      <h1 class="text-xl text-green-400 font-medium title-font mb-4">Archived Media Items</h1>
-      <a class="px-2" href="#">
-        <%= link_to twitter_user_download_path do %>
-          <span class="text-xl font-medium title-font mb-4">↓</span>
-        <% end %>
-      </a>
+    <div class="author__metadata">
+      <%= abbreviate_number(@twitter_user.followers_count) %>
+      <%= "follower".pluralize(@twitter_user.followers_count) %>
+      •
+      <%= abbreviate_number(@twitter_user.following_count) %>
+      following
+      •
+      <%= @twitter_user.location %>
     </div>
-    <div class="h-1 w-50 bg-pink-200 rounded"></div>
-    <div class="flex flex-wrap-m-4">
-      <% @archive_items.each do |tweet| %>
-      <div class="xl:w-1/2 md:w-1 p-4">
-        <div class="bg-white border-gray-200 border p-6 rounded-lg">
-          <h3 class="tracking-widest pb-3 text-green-400 text-xs font-medium title-font">Twitter</h3>
-          <% if tweet.images.empty? == false %>
-          <img src="<%= tweet.images.first.image_url %>" class="w-40 h-40 mb-5 inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
-          <% elsif tweet.videos.empty? == false %>
-          <video
-            width="320"
-            height="240"
-            poster="<%= tweet.videos.first.video_derivatives[:preview].url %>"
-            controls>
-            <source src="<%= tweet.videos.first.video_url %>" type="video/mp4">
-            Your browser does not support the video tag.
-          </video>
-          <% end %>
-          <p class="leading-relaxed pb-3 text-base"><%= tweet.text %></p>
-          <h3 class="text-lg text-gray-900 font-medium title-font mb-4"><%= tweet.posted_at %></h3>
-        </div>
-      </div>
+    <div class="author__description">
+      <%= @twitter_user.description %>
+    </div>
+    <div class="author__metadata">
+      <span class="icon-prefixed">
+        <svg class="icon icon--xl"><use xlink:href="#svg-calendar-outline"></use></svg>
+        <span>
+          Joined Twitter on
+          <time
+            datetime="<%= @twitter_user.sign_up_date.iso8601 %>"
+            data-author-target="timestamp"
+          >
+            <%= @twitter_user.sign_up_date %>
+          </time>
+        </span>
+    </div>
+  </div>
+</div>
+
+<div class="author-archive">
+  <div class="author-archive__header">
+    <h2 class="author-archive__title">
+      <span class="author-archive__title__archive-size"><%= @archive_items.length %></span>
+      <%= "item".pluralize(@archive_items.length) %>
+      archived
+    </h2>
+    <div class="author-archive__actions">
+      <%= link_to twitter_user_download_path, {
+        title: "Download user archive in JSON format",
+        class: "btn icon-prefixed",
+        download: true
+      } do %>
+        <svg class="icon icon--lg"><use xlink:href="#svg-download-outline"></use></svg>
+        JSON
       <% end %>
     </div>
   </div>
-</section>
+  <div class="archive-items archive-items--masonry archive-items--boxed-items">
+    <% @archive_items.each do |archive_item| %>
+      <%= render partial: "archive/archive_item", locals: {
+        **archive_item.normalized_attrs_for_views,
+        include_author: false
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/youtube_channels/show.html.erb
+++ b/app/views/youtube_channels/show.html.erb
@@ -1,45 +1,67 @@
-<section class="text-gray-600 body-font">
-  <div class="container px-5 py-24 mx-auto">
-    <div class="flex flex-wrap w-full mb-20">
-      <div class="lg:w-1/2 w-full mb-6 lg:mb-0">
-        <img src="<%= @youtube_channel.channel_image_url %>" class="w-40 h-40 mb-5 rounded-full inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
-        <div class="h-1 w-20 bg-pink-200 rounded"></div>
-        <h1 class="sm:text-3xl text-2xl font-medium title-font mb-2 mt-3 text-gray-900">@<%= @youtube_channel.title %></h1>
-      </div>
-      <div class="lg:w-1/2 w-full leading-relaxed text-gray-500 bg-white border-gray-200 border p-6 rounded-lg">
-        <h3 class="tracking-widest pb-3 text-green-400 text-xs font-medium title-font">Account Details</h3>
-        <ul>
-          <li><span class="text-gray-400">Title:</span> <span class="text-lg"><%= @youtube_channel.title %></span></li>
-          <li><span class="text-gray-400"># of Subscribers:</span> <span class="text-lg"><%= @youtube_channel.num_subscribers %></span></li>
-          <li><span class="text-gray-400"># of Videos:</span> <span class="text-lg"><%= @youtube_channel.num_videos %></span></li>
-          <li><span class="text-gray-400"># of Views:</span> <span class="text-lg"><%= @youtube_channel.num_views %></span></li>
-          <br />
-          <li><span class="text-gray-400">Description:</span> <span class="text-lg"><%= @youtube_channel.description %></span></li>
-        </ul>
-      </div>
+<div class="author" data-controller="author">
+  <img
+    class="author__image"
+    src="<%= @youtube_channel.channel_image_url %>"
+    width="300" height="300"
+    alt="Profile photo of <%= @youtube_channel.title %>"
+  >
+  <div class="author__profile">
+    <div class="author__name">
+      <span class="author__display-name"><%= @youtube_channel.title %></span>
     </div>
-    <div class="flex">
-      <h1 class="text-xl text-green-400 font-medium title-font mb-4">Archived Media Items</h1>
+    <div class="author__metadata">
+      <%= abbreviate_number(@youtube_channel.num_subscribers) %>
+      <%= "subscriber".pluralize(@youtube_channel.num_subscribers) %>
+      •
+      <%= abbreviate_number(@youtube_channel.num_views) %>
+      <%= "view".pluralize(@youtube_channel.num_views) %>
+      •
+      <%= abbreviate_number(@youtube_channel.num_videos) %>
+      <%= "video".pluralize(@youtube_channel.num_videos) %>
     </div>
-    <div class="flex flex-wrap-m-4">
-      <% @archive_items.each do |youtube_post| %>
-      <div class="xl:w-1/2 md:w-1 p-4">
-        <div class="bg-white border-gray-200 border p-6 rounded-lg">
-          <h3 class="tracking-widest pb-3 text-green-400 text-xs font-medium title-font">Youtube Posts</h3>
-          <video
-            width="320"
-            height="240"
-            poster="<%= youtube_post.videos.first.video_derivatives[:preview].url %>"
-            controls>
-            <source src="<%= youtube_post.videos.first.video_url %>" type="video/mp4">
-            Your browser does not support the video tag.
-          </video>
-          <p class="leading-relaxed pb-3 text-base"><%#= youtube_post.text %></p>
-          <h3 class="text-lg text-gray-900 font-medium title-font mb-4"><%= youtube_post.posted_at %></h3>
-        </div>
-      </div>
+    <div class="author__description">
+      <%= @youtube_channel.description %>
+    </div>
+    <div class="author__metadata">
+      <span class="icon-prefixed">
+        <svg class="icon icon--xl"><use xlink:href="#svg-calendar-outline"></use></svg>
+        <span>
+          Channel created on
+          <time
+            datetime="<%= @youtube_channel.sign_up_date.iso8601 %>"
+            data-author-target="timestamp"
+          >
+            <%= @youtube_channel.sign_up_date %>
+          </time>
+        </span>
+    </div>
+  </div>
+</div>
+
+<div class="author-archive">
+  <div class="author-archive__header">
+    <h2 class="author-archive__title">
+      <span class="author-archive__title__archive-size"><%= @archive_items.length %></span>
+      <%= "item".pluralize(@archive_items.length) %>
+      archived
+    </h2>
+    <div class="author-archive__actions">
+      <%= link_to youtube_channel_download_path, {
+        title: "Download channel archive in JSON format",
+        class: "btn icon-prefixed",
+        download: true
+      } do %>
+        <svg class="icon icon--lg"><use xlink:href="#svg-download-outline"></use></svg>
+        JSON
       <% end %>
     </div>
   </div>
-</section>
-
+  <div class="archive-items archive-items--masonry archive-items--boxed-items">
+    <% @archive_items.each do |archive_item| %>
+      <%= render partial: "archive/archive_item", locals: {
+        **archive_item.normalized_attrs_for_views,
+        include_author: false
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,4 +48,5 @@ Rails.application.routes.draw do
   get "/facebook_users/:id/download", to: "facebook_users#export_facebook_user_data", as: "facebook_user_download"
   get "/instagram_users/:id/download", to: "instagram_users#export_instagram_user_data", as: "instagram_user_download"
   get "/twitter_users/:id/download", to: "twitter_users#export_tweeter_data", as: "twitter_user_download"
+  get "/youtube_channels/:id/download", to: "youtube_channels#export_youtube_channel_data", as: "youtube_channel_download"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
   put "/organizations/:organization_id/update_admin/:user_id", to: "organizations#update_admin", as: "organization_update_admin"
   delete "/organizations/:organization_id/update_admin/:user_id", to: "organizations#delete_user", as: "organization_delete_user"
 
+  get "/facebook_users/:id/download", to: "facebook_users#export_facebook_user_data", as: "facebook_user_download"
   get "/instagram_users/:id/download", to: "instagram_users#export_instagram_user_data", as: "instagram_user_download"
   get "/twitter_users/:id/download", to: "twitter_users#export_tweeter_data", as: "twitter_user_download"
 end


### PR DESCRIPTION
This PR significantly redesigns the user pages.

**Before:**
<img width="1269" alt="before" src="https://user-images.githubusercontent.com/4731/174124603-d729851f-ff69-4564-9fd7-a2e2dc6ed144.png">

**After:**
<img width="1284" alt="after" src="https://user-images.githubusercontent.com/4731/174124609-6d7338a6-63b6-4acf-931a-b91c5e6f02f7.png">

⚠️ The "After" screenshot shows a masonry-style layout that actually only works (1) in Firefox and (2) after enabling an experimental feature. :( You'll likely actually see a slightly different and less compact layout.

**Testing:**
- Scan the code, how's it look? Sensible?
- `./bin/dev`, go to the Most Recent Archived Items page, and click on the author.