### PR TITLE
Add `lint:js` Yarn script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds",
     "build:css": "tailwindcss --postcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify",
+    "lint:js": "eslint app/javascript",
     "postinstall": "patch-package"
   }
 }


### PR DESCRIPTION
This PR comes out of the #233 confusion. It adds a simple `lint:js` Yarn script to our `package.json` that makes sure to lint using the actual Node package.

**Testing:**
- Run `yarn lint:js`
- You should get output like this:
   ```
   ➜  zenodotus git:(add-lint-js-script) yarn lint:js
   yarn run v1.22.19
   $ eslint app/javascript
   ✨  Done in 0.99s.
   ```