### PR TITLE
Hotfix: Limit archive index to 50 items

### DIFF
--- a/app/controllers/archive_controller.rb
+++ b/app/controllers/archive_controller.rb
@@ -9,10 +9,10 @@ class ArchiveController < ApplicationController
   def index
     respond_to do | format |
       if current_user.nil? || current_user.restricted
-        @archive_items = ArchiveItem.includes(:media_review, archivable_item: [:author]).order("created_at DESC")
+        @archive_items = ArchiveItem.includes(:media_review, archivable_item: [:author]).limit(50).order("created_at DESC")
         format.html { render "limited_index" }
       else
-        @archive_items = ArchiveItem.includes(:media_review, { archivable_item: [:author, :images, :videos] }).order("created_at DESC")
+        @archive_items = ArchiveItem.includes(:media_review, { archivable_item: [:author, :images, :videos] }).limit(50).order("created_at DESC")
         format.html { render "index" }
       end
     end


### PR DESCRIPTION
This PR hotfixes the archive index to only return the most recent 50 items, because otherwise it shows the entire index. This slows the page way down.

We need to [add pagination](https://github.com/TechAndCheck/zenodotus/issues/241), but this will be a stopgap until then.