### PR TITLE
Hotfix Facebook views

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.6-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     oauth (0.5.8)
@@ -375,6 +377,7 @@ GEM
       sorbet-coerce (>= 0.2.6)
       sorbet-runtime (>= 0.5)
     sorbet-runtime (0.5.9964)
+    sorbet-static (0.5.9914-universal-darwin-19)
     sorbet-static (0.5.9914-universal-darwin-21)
     sorbet-static (0.5.9914-x86_64-linux)
     sorted_set (1.0.3)
@@ -442,6 +445,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES

--- a/app/models/sources/facebook_post.rb
+++ b/app/models/sources/facebook_post.rb
@@ -142,6 +142,35 @@ class Sources::FacebookPost < ApplicationRecord
     facebook_id
   end
 
+  sig { returns(Integer) }
+  def number_of_likes
+    reactions["num_likes"]
+  end
+
+  sig { returns(Integer) }
+  def number_of_haha_reactions
+    reactions["num_hahas"]
+  end
+
+  sig { returns(Integer) }
+  def number_of_angry_reactions
+    reactions["num_angrys"]
+  end
+
+  sig { returns(Integer) }
+  def number_of_love_reactions
+    reactions["num_loves"]
+  end
+
+  sig { returns(Integer) }
+  def number_of_care_reactions
+    reactions["num_cares"]
+  end
+
+  sig { returns(Integer) }
+  def number_of_sad_reactions
+    reactions["num_sads"]
+  end
   # Normalized representation of this archivable item for use in the view template.
   #
   # @returns Hash of normalized attributes.

--- a/app/views/text_search/_search_result_facebook_post.html.erb
+++ b/app/views/text_search/_search_result_facebook_post.html.erb
@@ -53,9 +53,9 @@
         <div class="p-1 rounded-full bg-gradient-to-r from-purple-500 to-red-600 inline-block">
             <img src="/uploads/<%= result.author.profile_image_data["id"] %>" class="w-20 h-20 rounded-full inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
         </div>
-        <%= result.author.handle %>
+        <%= result.author.name %>
       <%end%>
-      <a href="#"><p class="text-base"><%= result.author.display_name %></p></a>
+      <a href="#"><p class="text-base"><%= result.author.name %></p></a>
     </div>
   </div>
 </div>

--- a/test/models/facebook_post_test.rb
+++ b/test/models/facebook_post_test.rb
@@ -29,6 +29,9 @@ class FacebookPostTest < ActiveSupport::TestCase
     assert_equal Time.at(@@forki_post.first["post"]["created_at"]).utc.strftime("%FT%T%:z"), archive_item.facebook_post.posted_at.strftime("%FT%T%:z")
 
     assert_not_nil archive_item.facebook_post.author
+    assert archive_item.facebook_post.number_of_likes.positive?
+    assert archive_item.facebook_post.number_of_love_reactions.positive?
+
     assert_not_nil archive_item.facebook_post.images
   end
 


### PR DESCRIPTION
- Add helper methods to access Facebook reaction counts. 
- Correct attribute paths in Facebook views

test: `rails t`