### PR TITLE
Properly render media previews in search results

### DIFF
--- a/app/views/archive/_item_media_preview.html.erb
+++ b/app/views/archive/_item_media_preview.html.erb
@@ -4,8 +4,6 @@
     <div>
         <figure class="relative m-0 text-center">
         <video
-            width="320"
-            height="240"
             poster="<%= item.videos.first.video_derivatives[:preview].url %>"
             controls >
             <source src="<%= item.videos.first.video_url %>" type="video/mp4">

--- a/app/views/text_search/_search_result_facebook_post.html.erb
+++ b/app/views/text_search/_search_result_facebook_post.html.erb
@@ -1,9 +1,13 @@
 <div class="border rounded mb-5 flex flex-col md:flex-row p-6 md:h-48 md:w-auto text-sm">
   <div class="flex-none h-96 mb-5 md:mb-0 md:h-auto md:w-32 overflow-hidden rounded">
-    <% if result.images.empty? %>
-      <div></div>
+    <% if result.videos.length.positive? %>
+      <div>
+        <a href="#"><img src="<%= result.videos.first.video_derivatives[:preview].url %>"/></a>
+      </div>
+    <% elsif result.images.length.positive? %>
+      <a href="#"><img src="<%= result.images.first.image.url %>"/></a>
     <% else %>
-      <a href="#"><img src="/uploads/<%=  result.images.first["id"]  %>"/></a>
+      <div></div>
     <% end %>
   </div>
   <div class="overflow-hidden md:pl-5 mr-5 flex flex-col md:flex-row w-full text-left justify-around">

--- a/app/views/text_search/_search_result_instagram_post.html.erb
+++ b/app/views/text_search/_search_result_instagram_post.html.erb
@@ -1,9 +1,13 @@
 <div class="border rounded mb-5 flex flex-col md:flex-row p-6 md:h-48 md:w-auto text-sm">
   <div class="flex-none h-96 mb-5 md:mb-0 md:h-auto md:w-32 overflow-hidden rounded">
-    <% if result.images.empty? %>
-      <div></div>
+    <% if result.videos.length.positive? %>
+      <div>
+        <a href="#"><img src="<%= result.videos.first.video_derivatives[:preview].url %>"/></a>
+      </div>
+    <% elsif result.images.length.positive? %>
+      <a href="#"><img src="<%= result.images.first.image.url %>"/></a>
     <% else %>
-      <a href="#"><img src="/uploads/<%=  result.images.first["id"]  %>"/></a>
+      <div></div>
     <% end %>
   </div>
   <div class="overflow-hidden md:pl-5 mr-5 flex flex-col md:flex-row w-full text-left justify-around">

--- a/app/views/text_search/_search_result_tweet.html.erb
+++ b/app/views/text_search/_search_result_tweet.html.erb
@@ -1,9 +1,11 @@
 <div class="border rounded mb-5 flex flex-col md:flex-row p-6 md:h-48 md:w-auto text-sm">
   <div class="flex-none h-96 mb-5 md:mb-0 md:h-auto md:w-32 overflow-hidden rounded">
-    <% if result.images.empty? %>
-      <div></div>
+    <% if result.videos.length.positive? %>
+      <a href="#"><img src="<%= result.videos.first.video_derivatives[:preview].url %>"/></a>
+    <% elsif result.images.length.positive? %>
+      <a href="#"><img src="<%=  result.images.first.image.url %>"/></a>
     <% else %>
-      <a href="#"><img src="/uploads/<%=  result.images.first["id"]  %>"/></a>
+      <div></div>
     <% end %>
   </div>
   <div class="overflow-hidden md:pl-5 mr-5 flex flex-col md:flex-row w-full text-left justify-around">

--- a/app/views/text_search/_search_result_youtube_post.html.erb
+++ b/app/views/text_search/_search_result_youtube_post.html.erb
@@ -1,6 +1,6 @@
 <div class="border rounded mb-5 flex flex-col md:flex-row p-6 md:h-48 md:w-auto text-sm">
   <div class="flex-none h-96 mb-5 md:mb-0 md:h-auto md:w-32 overflow-hidden rounded">
-    <a href="#"><img src="/uploads/<%= result.preview_image_data["id"] %>"/></a>
+    <a href="#"><img src="<%= result.preview_image.url %>"/></a>
   </div>
   <div class="overflow-hidden md:pl-5 mr-5 flex flex-col md:flex-row w-full text-left justify-around">
     <div class="flex flex-col flex-wrap justify-around">


### PR DESCRIPTION
The current text search result views in `master` don't render video preview images. This PR resolves that 

Testing
1. load image and video posts from each of the sources
2. Search for text in the posts
3. See preview images

NOTE: I can't log into Instagram right now, so I wasn't able to test media from the platform

