### PR TITLE
Hide inaccessible user-related routes and pages

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -76,7 +76,6 @@
           <% end %>
         <% else %>
           <li><%= link_to "Log in", new_user_session_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
-          <li><%= link_to "Request account", new_user_registration_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
         <% end %>
       </ul>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 # typed: false
 Rails.application.routes.draw do
-  devise_for :users,
-             controllers: {
-               sessions: "users/sessions"
-             }
+  devise_scope :user do
+    get "users/sign_in", to: "users/sessions#new", as: "new_user_session"
+    post "users/sign_in", to: "users/sessions#create", as: "user_session"
+    delete "users/sign_out", to: "users/sessions#destroy", as: "destroy_user_session"
+  end
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   # root "login#index"


### PR DESCRIPTION
This PR is a "step backwards to go forwards" thing. It reduces our Devise routes down to just session login/logout, since nothing else is wired up or working. This way testers (and ourselves) don't stumble upon them.

Affects #153 