### PR TITLE
Provide proper type signatures to Scrape methods

### DIFF
--- a/app/models/scrape.rb
+++ b/app/models/scrape.rb
@@ -4,7 +4,7 @@ class Scrape < ApplicationRecord
 
     attr_reader :url
 
-    sig { params(url: String) }
+    sig { params(url: String).void }
     def initialize(url)
       @url = url
       super("Media review with url: #{url} for scrape fulfillment not found.")
@@ -17,6 +17,7 @@ class Scrape < ApplicationRecord
 
   has_one :archive_item, dependent: :destroy
 
+  sig { params(response: String).void }
   def fulfill(response)
     response = JSON.parse(response)
 


### PR DESCRIPTION
This PR adds complete type signatures to the `Scrape#initialize` and `Scrape#fulfill` methods. (Please verify that these signatures are correct! I'm going on my own assumptions here.)

**Testing:**
1. On `master`, run `rails t test/controllers/archive_controller_test.rb`. It should ❌ fail with a complaint about the method type signature.
2. On `248-add-scrape-sigs`, run that test again. It should ✅ succeed (or at least, fail somewhere different than on type sigs).

Resolves #248