### PR TITLE
Fixes bug in Facebook user deduplication script

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -9,6 +9,7 @@ namespace :users do
       other_users = Sources::FacebookUser.where(facebook_id: user.facebook_id)
       # run through those and add all the posts to this user
       other_users.each do |other_user|
+        next if other_user == user  # Don't compare self to self
         other_user.facebook_posts.each do |post|
           post.update!({ author_id: user.id })
         end


### PR DESCRIPTION
Previously, we compared each facebook user to all other users with the same facebook id, then deleted them. Unfortunately, we compared users to themselves and ended up deleting all users. Now we don't!

# Testing
```
rails users:dedup_facebook
```