### PR TITLE
Hide unused user routes and pages

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -76,7 +76,6 @@
           <% end %>
         <% else %>
           <li><%= link_to "Log in", new_user_session_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
-          <li><%= link_to "Request account", new_user_registration_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
         <% end %>
       </ul>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,23 @@
 
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  # These routes come along automatically from Devise, but we don't want them to (for now).
+  # Thus, we redirect them to the root. Must be declared before the `devise_for` block below.
+  get "users/cancel", to: redirect("/")
+  get "users/sign_up", to: redirect("/")
+  get "users/edit", to: redirect("/")
+
+  # This generates only the session and registration-related Devise URLs. We actually only want the
+  # session URLs for the userspace, but the registration-related routes are necessary for tests to
+  # run properly. (The ones that we override above also come from this. If we can somehow exclude
+  # them in this configuration block, that would be amazing.)
   devise_for :users,
+             skip: :all,
+             only: [:sessions, :registrations],
              controllers: {
-               sessions: "users/sessions"
+               sessions: "users/sessions",
+               registrations: "devise/registrations"
              }
 
   root "archive#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,19 +1,17 @@
 # typed: false
+
 Rails.application.routes.draw do
+  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   devise_for :users,
              controllers: {
                sessions: "users/sessions"
              }
 
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  # root "login#index"
   root "archive#index"
 
   get "/archive/add", to: "archive#add"
   post "/archive/add", to: "archive#submit_url"
-
   get "/archive/download", to: "archive#export_archive_data", as: "archive_download"
-
   post "/archive/scrape_result_callback", to: "archive#scrape_result_callback", as: "scrape_result_callback"
 
   post "/ingest/submit_media_review", to: "ingest#submit_media_review", as: "ingest_api_raw"
@@ -34,7 +32,7 @@ Rails.application.routes.draw do
 
   get "/jobs", to: "jobs_status#index", as: "jobs_status_index"
   delete "/jobs/:id", to: "jobs_status#delete_job", as: "job_status_delete"
-  post "jobs/resubmit/:id", to: "jobs_status#resubmit_scrape", as: "job_status_resubmit"
+  post "/jobs/resubmit/:id", to: "jobs_status#resubmit_scrape", as: "job_status_resubmit"
 
   resources :twitter_users, only: [:show]
   resources :instagram_users, only: [:show]


### PR DESCRIPTION
This PR just hides some of the in-progress parts of the site so people demoing it don't stumble into unusable areas. Mostly, it suppresses the account signup screens that Devise auto-provides that don't actually do anything yet. This is all somewhat temporary until we actually finish out #153.

There's a bit of redirection duct tape in the routes file that I'm not keen on, but I got tired of trying to dig out Devise's guts.

**Testing:**
- Run the app to make sure logging in/out and changing user settings still works
- Run tests; I was getting inconsistent results that worry me a bit but I think it was specific to my machine?