### PR TITLE
Add screenshots to data model

### DIFF
--- a/app/models/archive_item.rb
+++ b/app/models/archive_item.rb
@@ -9,6 +9,8 @@ class ArchiveItem < ApplicationRecord
   delegate :videos, to: :archivable_item
 
   has_one :media_review, dependent: :destroy, foreign_key: :archive_item_id
+  has_one :screenshot, dependent: :destroy, foreign_key: :archive_item_id, class_name: "Screenshot"
+  accepts_nested_attributes_for :screenshot, allow_destroy: true
   has_many :image_hashes, dependent: :destroy
   belongs_to :submitter, optional: true, class_name: "User"
   belongs_to :scrape, optional: true

--- a/app/models/screenshot.rb
+++ b/app/models/screenshot.rb
@@ -1,0 +1,8 @@
+# typed: false
+class Screenshot < ApplicationRecord
+  include ImageUploader::Attachment(:image)
+
+  # Optional is marked true here because the image is technically saved before
+  # it's added to the model itself.
+  belongs_to :archive_item, optional: true, class_name: "ArchiveItem"
+end

--- a/app/models/sources/facebook_post.rb
+++ b/app/models/sources/facebook_post.rb
@@ -84,12 +84,12 @@ class Sources::FacebookPost < ApplicationRecord
 
       image_attributes = []
       video_attributes = []
-      screenshot_attributes = []
+      screenshot_attributes = {}
 
       # We want to default to using the AWS key if it's available, and fallback to Base64 if it's not
       if forki_post["aws_screenshot_key"].present?
         downloaded_path = AwsS3Downloader.download_file_in_s3_received_from_hypatia(forki_post["aws_screenshot_key"])
-        screenshot_attributes = [ { image: File.open(downloaded_path, binmode: true) } ]
+        screenshot_attributes = { image: File.open(downloaded_path, binmode: true) }
       else
         tempfile = Tempfile.new(binmode: true)
         tempfile.write(Base64.decode64(forki_post["screenshot_file"]))

--- a/app/models/sources/instagram_post.rb
+++ b/app/models/sources/instagram_post.rb
@@ -86,11 +86,11 @@ class Sources::InstagramPost < ApplicationRecord
 
       image_attributes = []
       video_attributes = []
-      screenshot_attributes = []
+      screenshot_attributes = {}
 
       if zorki_post["aws_screenshot_key"].present?
         downloaded_path = AwsS3Downloader.download_file_in_s3_received_from_hypatia(zorki_post["aws_screenshot_key"])
-        screenshot_attributes = [ { image: File.open(downloaded_path, binmode: true) } ]
+        screenshot_attributes = { image: File.open(downloaded_path, binmode: true) }
       else
         tempfile = Tempfile.new(binmode: true)
         tempfile.write(Base64.decode64(zorki_post["screenshot_file"]))

--- a/app/models/sources/tweet.rb
+++ b/app/models/sources/tweet.rb
@@ -89,12 +89,13 @@ class Sources::Tweet < ApplicationRecord
         { video: File.open(video_file_name.first, binmode: true), video_type: birdsong_tweet.video_file_type }
       end
 
-      if birdsong_tweet["aws_screenshot_key"].present?
-        downloaded_path = AwsS3Downloader.download_file_in_s3_received_from_hypatia(birdsong_tweet["aws_screenshot_key"])
-        screenshot_attributes = { image: File.open(downloaded_path, binmode: true) }
-      else
-        screenshot_attributes = { image: File.open(birdsong_tweet["screenshot_file"], binmode: true) }
-      end
+      # TODO: Uncomment this after Birdsong has been migrated to Hypatia
+      # if birdsong_tweet["aws_screenshot_key"].present?
+      #   downloaded_path = AwsS3Downloader.download_file_in_s3_received_from_hypatia(birdsong_tweet["aws_screenshot_key"])
+      #   screenshot_attributes = { image: File.open(downloaded_path, binmode: true) }
+      # else
+      #   screenshot_attributes = { image: File.open(birdsong_tweet["screenshot_file"], binmode: true) }
+      # end
 
       tweet_hash = {
         text:                  birdsong_tweet.text,

--- a/app/models/sources/tweet.rb
+++ b/app/models/sources/tweet.rb
@@ -79,7 +79,7 @@ class Sources::Tweet < ApplicationRecord
     birdsong_tweets.map do |birdsong_tweet|
       twitter_user = Sources::TwitterUser.create_from_birdsong_hash([birdsong_tweet.author]).first.twitter_user
 
-      screenshot_attributes = []
+      screenshot_attributes = {}
 
       image_attributes = birdsong_tweet.image_file_names.map do |image_file_name|
         { image: File.open(image_file_name, binmode: true) }
@@ -91,7 +91,7 @@ class Sources::Tweet < ApplicationRecord
 
       if birdsong_tweet["aws_screenshot_key"].present?
         downloaded_path = AwsS3Downloader.download_file_in_s3_received_from_hypatia(birdsong_tweet["aws_screenshot_key"])
-        screenshot_attributes = [ { image: File.open(downloaded_path, binmode: true) } ]
+        screenshot_attributes = { image: File.open(downloaded_path, binmode: true) }
       else
         screenshot_attributes = { image: File.open(birdsong_tweet["screenshot_file"], binmode: true) }
       end

--- a/app/models/sources/youtube_post.rb
+++ b/app/models/sources/youtube_post.rb
@@ -95,7 +95,7 @@ class Sources::YoutubePost < ApplicationRecord
       # Download screenshot from s3 or load it from base64 attachment
       if youtube_archiver_video["aws_screenshot_key"].present?
         downloaded_path = AwsS3Downloader.download_file_in_s3_received_from_hypatia(youtube_archiver_video["aws_screenshot_key"])
-        screenshot_attributes = [ { image: File.open(downloaded_path, binmode: true) } ]
+        screenshot_attributes = { image: File.open(downloaded_path, binmode: true) }
       else
         tempfile = Tempfile.new(binmode: true)
         tempfile.write(Base64.decode64(youtube_archiver_video["screenshot_file"]))

--- a/db/migrate/20220725202113_add_screenshots_to_archive_items.rb
+++ b/db/migrate/20220725202113_add_screenshots_to_archive_items.rb
@@ -1,0 +1,9 @@
+class AddScreenshotsToArchiveItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :screenshots, id: :uuid do |t|
+      t.references :archive_item, type: :uuid, foreign_key: true
+      t.jsonb      :image_data
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220818155939_remove_preview_image_from_youtube_posts.rb
+++ b/db/migrate/20220818155939_remove_preview_image_from_youtube_posts.rb
@@ -1,0 +1,5 @@
+class RemovePreviewImageFromYoutubePosts < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :youtube_posts, :preview_image_data
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_25_202113) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_18_155939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -306,7 +306,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_25_202113) do
     t.string "language"
     t.string "channel_id"
     t.boolean "made_for_kids"
-    t.jsonb "preview_image_data", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_16_162441) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_25_202113) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -190,6 +190,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_16_162441) do
     t.boolean "error"
   end
 
+  create_table "screenshots", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "archive_item_id"
+    t.jsonb "image_data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["archive_item_id"], name: "index_screenshots_on_archive_item_id"
+  end
+
   create_table "text_searches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -319,6 +327,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_16_162441) do
   add_foreign_key "instagram_videos", "instagram_posts"
   add_foreign_key "media_reviews", "archive_items"
   add_foreign_key "organizations", "users", column: "admin_id"
+  add_foreign_key "screenshots", "archive_items"
   add_foreign_key "text_searches", "users"
   add_foreign_key "twitter_images", "tweets"
   add_foreign_key "twitter_videos", "tweets"

--- a/test/models/archive_item_test.rb
+++ b/test/models/archive_item_test.rb
@@ -18,4 +18,10 @@ class ArchiveItemTest < ActionDispatch::IntegrationTest
     User.destroy(users(:user3).id)
     assert_nil ArchiveItem.first.submitter
   end
+
+  test "scraping a post creates a screenshot" do
+    forki_post = FacebookMediaSource.extract("https://www.facebook.com/Meta/photos/a.108824087345859/336596487901950", true)["scrape_result"]
+    archive_item = Sources::FacebookPost.create_from_forki_hash(forki_post).first
+    assert_not_nil archive_item.screenshot
+  end
 end


### PR DESCRIPTION
This PR creates a `screenshot` model and establishes a `has-one` relationship between `ArchiveItems` and `screenshots`. It synchronizes with https://github.com/TechAndCheck/hypatia/pull/46, which allows screenshots to be transmitted between the scrapers/Hypatia and Zenodotus. 

# Testing
Zenodotus testing is in a rough spot right now. Because tests require immediate results, most of them use the `force` keyword to bypass ActiveJob and skip Hypatia's job queue. But since in production, all jobs will queue, we need queueing tests, too. 

This mix of queuing and non-queueing jobs causes problems in Hypatia. Namely, Hypatia will pop a job off its queue and begin running it, even when a non-queued "forced" job is already running. This sends Selenium into a tizzy and causes cascading errors. 

[Issue] addresses the need to resolve ^, which we can do through mocks. 

Given the above, we have a couple ways we can move forward with this PR
1. Rambo merge the PR and check for errors  once we've built mocks and can run our other tests properly
2. Ice this PR until mocks are ready
3. Run individual tests in a hacky fashion

More details on 3: 
Our Zenodotus test issues arise from ActiveJob tests interfering with non-ActiveJob tests. We can force `ActiveJob` tests to run last by moving them to the end of each test file and adding 
```ruby
def self.runnable_methods
   methods = methods_matching(/^test_/)
end
```
This should let us run an entire file of tests at a time. Unfortunately it won't work for multiple files, because the `ActiveJob` tests at the end of a file will interfere with the non-`ActiveJob` tests at the beginning of the next file. 

<details>
<summary>FacebookPostTest output (all tests pass)</summary>

```
(p3ten) grog@MedianLebowski:~/hub/zenodotus$ rails t test/models/facebook_post_test.rb
Run options: --seed 63088

.# Running:

(rails:30426): VIPS-WARNING **: 15:49:18.007: rounding up IPTC data length

(rails:30426): VIPS-WARNING **: 15:49:18.096: rounding up IPTC data length
.I, [2022-08-19T15:49:19.486108 #30426]  INFO -- : Running transcoding...
["/usr/bin/ffmpeg", "-y", "-i", "/tmp/shrine20220819-30426-my7seu.mp4", "-vframes", "1", "-f", "image2", "/tmp/8f50727b-d208-440d-a7f1-b3e3602a7760-preview20220819-30426-7jbkhq.jpg"]

I, [2022-08-19T15:49:19.568100 #30426]  INFO -- : Transcoding of /tmp/shrine20220819-30426-my7seu.mp4 to /tmp/8f50727b-d208-440d-a7f1-b3e3602a7760-preview20220819-30426-7jbkhq.jpg succeeded

...DEPRECATED: Use assert_nil if expecting nil from test/models/facebook_post_test.rb:29. This will fail in Minitest 6.
...I, [2022-08-19T15:49:49.260173 #30426]  INFO -- : Running transcoding...
["/usr/bin/ffmpeg", "-y", "-i", "/tmp/shrine20220819-30426-xq6klw.mp4", "-vframes", "1", "-f", "image2", "/tmp/c00947c3-bcc2-44d5-aa0a-7d30369a7101-preview20220819-30426-rg4932.jpg"]

I, [2022-08-19T15:49:49.344481 #30426]  INFO -- : Transcoding of /tmp/shrine20220819-30426-xq6klw.mp4 to /tmp/c00947c3-bcc2-44d5-aa0a-7d30369a7101-preview20220819-30426-rg4932.jpg succeeded

..

Finished in 170.387356s, 0.0528 runs/s, 0.1409 assertions/s.
9 runs, 24 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /home/grog/hub/zenodotus/coverage. 337 / 1866 LOC (18.06%) covered.
```
</details>

<details>
<summary>YoutubePostTest output (all tests pass)</summary>

```
(p3ten) grog@MedianLebowski:~/hub/zenodotus$ rails t test/models/youtube_post_test.rb
Run options: --seed 53539

# Running:

I, [2022-08-19T16:39:54.958112 #25663]  INFO -- : Running transcoding...
["/usr/bin/ffmpeg", "-y", "-i", "/tmp/shrine20220819-25663-2ykejg.mp4", "-vframes", "1", "-f", "image2", "/tmp/4a5890a1-6e93-4c1a-904b-278b647f1a71-preview20220819-25663-c9zx4p.jpg"]

I, [2022-08-19T16:39:55.067108 #25663]  INFO -- : Transcoding of /tmp/shrine20220819-25663-2ykejg.mp4 to /tmp/4a5890a1-6e93-4c1a-904b-278b647f1a71-preview20220819-25663-c9zx4p.jpg succeeded

.I, [2022-08-19T16:40:07.628182 #25663]  INFO -- : Running transcoding...
["/usr/bin/ffmpeg", "-y", "-i", "/tmp/shrine20220819-25663-1y812e.mp4", "-vframes", "1", "-f", "image2", "/tmp/a7bf1a0d-3426-41cc-a8b2-e44db6f7df72-preview20220819-25663-j5rhgi.jpg"]

I, [2022-08-19T16:40:07.733178 #25663]  INFO -- : Transcoding of /tmp/shrine20220819-25663-1y812e.mp4 to /tmp/a7bf1a0d-3426-41cc-a8b2-e44db6f7df72-preview20220819-25663-j5rhgi.jpg succeeded

I, [2022-08-19T16:40:20.008656 #25663]  INFO -- : Running transcoding...
["/usr/bin/ffmpeg", "-y", "-i", "/tmp/shrine20220819-25663-ven8yh.mp4", "-vframes", "1", "-f", "image2", "/tmp/69d757f4-6d7f-4c23-9b45-5bc2b07b629a-preview20220819-25663-rz2z00.jpg"]

I, [2022-08-19T16:40:20.116589 #25663]  INFO -- : Transcoding of /tmp/shrine20220819-25663-ven8yh.mp4 to /tmp/69d757f4-6d7f-4c23-9b45-5bc2b07b629a-preview20220819-25663-rz2z00.jpg succeeded

.I, [2022-08-19T16:41:31.710323 #25663]  INFO -- : Running transcoding...
["/usr/bin/ffmpeg", "-y", "-i", "/tmp/shrine20220819-25663-dzvynf.mp4", "-vframes", "1", "-f", "image2", "/tmp/46df2ad4-d8d6-4dc8-bf82-cb621085f7b7-preview20220819-25663-ctkoek.jpg"]

I, [2022-08-19T16:41:31.801169 #25663]  INFO -- : Transcoding of /tmp/shrine20220819-25663-dzvynf.mp4 to /tmp/46df2ad4-d8d6-4dc8-bf82-cb621085f7b7-preview20220819-25663-ctkoek.jpg succeeded

..I, [2022-08-19T16:41:35.515402 #25663]  INFO -- : Running transcoding...
["/usr/bin/ffmpeg", "-y", "-i", "/tmp/shrine20220819-25663-vnbv11.mp4", "-vframes", "1", "-f", "image2", "/tmp/fd8e1be2-69c3-45d5-b480-02878541801e-preview20220819-25663-c0e3ku.jpg"]

I, [2022-08-19T16:41:35.635488 #25663]  INFO -- : Transcoding of /tmp/shrine20220819-25663-vnbv11.mp4 to /tmp/fd8e1be2-69c3-45d5-b480-02878541801e-preview20220819-25663-c0e3ku.jpg succeeded

.I, [2022-08-19T16:41:47.877611 #25663]  INFO -- : Running transcoding...
["/usr/bin/ffmpeg", "-y", "-i", "/tmp/shrine20220819-25663-cmsv1m.mp4", "-vframes", "1", "-f", "image2", "/tmp/8876c110-8987-47ce-926a-4efe889e7788-preview20220819-25663-nlsc7o.jpg"]

I, [2022-08-19T16:41:47.985470 #25663]  INFO -- : Transcoding of /tmp/shrine20220819-25663-cmsv1m.mp4 to /tmp/8876c110-8987-47ce-926a-4efe889e7788-preview20220819-25663-nlsc7o.jpg succeeded

.Beginning to scrape https://www.youtube.com/watch?v=_ex8kfjfjXg @ 2022-08-19 16:41:49 -0400
Done scraping https://www.youtube.com/watch?v=_ex8kfjfjXg @ 2022-08-19 16:41:49 -0400
Beginning to scrape https://www.youtube.com/watch?v=LeOK7Dclq-Y @ 2022-08-19 16:41:49 -0400
Done scraping https://www.youtube.com/watch?v=LeOK7Dclq-Y @ 2022-08-19 16:41:49 -0400
.

Finished in 138.406987s, 0.0506 runs/s, 0.1445 assertions/s.
7 runs, 20 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /home/grog/hub/zenodotus/coverage. 328 / 1874 LOC (17.5%) covered.

```
InstagramPostTest: Tests are failing here, but they're also failing on Zenodotus `master`. It looks like there's something funny going on between Zenodotus and Hypatia here, because the links that posts we fail to scrape in tests _are_ scrapable using Hypatia's console. Happy to create a new issue to look at this.  