### PR TITLE
Mark Scrapes as Errored When They Are

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,5 @@
 # typed: ignore
+
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked

--- a/app/media_sources/facebook_media_source.rb
+++ b/app/media_sources/facebook_media_source.rb
@@ -1,4 +1,5 @@
 # typed: true
+
 class FacebookMediaSource < MediaSource
   include Forki
   attr_reader(:url)
@@ -72,7 +73,7 @@ class FacebookMediaSource < MediaSource
 
     raise ExternalServerError, "Error: #{response.code} returned from Hypatia server" unless response.code == 200
     response_body = JSON.parse(response.body)
-    raise InstagramMediaSource::ExternalServerError if response_body["success"] == false
+    raise ExternalServerError if response_body["success"] == false
 
     true
   end
@@ -93,7 +94,11 @@ class FacebookMediaSource < MediaSource
       params: params
     )
 
-    raise ExternalServerError, "Error: #{response.code} returned from Hypatia server" unless response.code == 200
+    unless response.code == 200
+      scrape.update!({ error: true })
+      raise ExternalServerError, "Error: #{response.code} returned from Hypatia server"
+    end
+
     returned_data = JSON.parse(response.body)
     returned_data["scrape_result"] = JSON.parse(returned_data["scrape_result"])
     returned_data

--- a/app/media_sources/instagram_media_source.rb
+++ b/app/media_sources/instagram_media_source.rb
@@ -82,7 +82,10 @@ class InstagramMediaSource < MediaSource
       params: params
     )
 
-    raise ExternalServerError, "Error: #{response.code} returned from Hypatia server" unless response.code == 200
+    unless response.code == 200
+      scrape.update!({ error: true })
+      raise ExternalServerError, "Error: #{response.code} returned from Hypatia server"
+    end
 
     # Hypatia returns arrays always so we grab the first
     returned_data = JSON.parse(response.body)

--- a/app/media_sources/youtube_media_source.rb
+++ b/app/media_sources/youtube_media_source.rb
@@ -1,4 +1,5 @@
 # typed: true
+
 class YoutubeMediaSource < MediaSource
   attr_reader(:url)
 
@@ -89,7 +90,11 @@ class YoutubeMediaSource < MediaSource
       params: params
     )
 
-    raise ExternalServerError, "Error: #{response.code} returned from external Hypatia server" unless response.code == 200
+    unless response.code == 200
+      scrape.update!({ error: true })
+      raise ExternalServerError, "Error: #{response.code} returned from Hypatia server"
+    end
+
     returned_data = JSON.parse(response.body)
     returned_data["scrape_result"] = JSON.parse(returned_data["scrape_result"])
     returned_data


### PR DESCRIPTION
Note: This is based off of PR #291 so do that first.

We were creating scrapes, but if there was an error raised by
a media_source we weren't marking the scrapes as errored. Whoops.

To test:
- Make sure Hypatia isn't connected
- Submit a new url
- While watching the job status page only one should should up