### PR TITLE
Improve video embedding

### DIFF
--- a/app/views/archive/_archive_item_media_inline_full.html.erb
+++ b/app/views/archive/_archive_item_media_inline_full.html.erb
@@ -8,6 +8,7 @@
             width="100%"
             height="auto"
             poster="<%= media.video_derivatives[:preview].url %>"
+            preload="none"
             controls
         >
             <source src="<%= media.video_url %>" type="video/mp4">


### PR DESCRIPTION
This PR disables video preloading, which happens automatically under certain browser/bandwidth conditions. With preloading allowed, then the browser would sometimes skip the poster and just download the full video; it's not clear what these conditions were, but it's possible we hit a timeout on the `poster` download and so triggered the preload-for-metadata process.

Now, we set`preload="none"` on all `<video>` elements to ensure the browser doesn't begin downloading the videos until the user actually plays the video. This is preferable anyway for us since we are usually showing multiple (sometimes very many) videos per page, with no confidence the user is likely to play any of them, but it should also ensure the browser waits around for the poster image and doesn't try to fetch the video for metadata / first frame.

**To test:**

1. On `master`, load up the Media Vault "home page" with your inspector open to the Network tab, filtered to Media. (Also make sure Disable Cache is checked.)
2. ❌ The videos are transferred even before you play them. (**Note:** You may not _always_ see this happen. The `preload` default is `auto`, which lets the browser decide based on network conditions and magic. The point is, though, it _can_ happen, and we really don't mean for it ever to.)
3. Switch to `258-fix-video-preloading` and perform the same check.
4. ✅ The videos aren't transferred until you play them.

Closes #258 