### PR TITLE
Add Request Access page

### DIFF
--- a/app/assets/stylesheets/forms.css
+++ b/app/assets/stylesheets/forms.css
@@ -123,3 +123,25 @@ Library for consistent form layout.
 .checkbox input {
 	margin-top: calc(((1rem * 1.5) - 1rem) / 2);
 }
+
+/* Errors */
+
+.field_with_errors label {
+	color: var(--color--mood--error);
+}
+
+.field__error-messages {
+	background-color: var(--color--mood--error);
+	color: white;
+	font-weight: var(--font-weight-medium);
+}
+
+.field__wrapper--input .field__error-messages {
+	border-radius: 0 0 5px 5px;
+	padding: 0.25rem 0.5rem;
+}
+
+.field__wrapper--checkboxes .field__error-messages {
+	display: inline-block;
+	padding: 0 0.25rem;
+}

--- a/app/assets/stylesheets/forms.css
+++ b/app/assets/stylesheets/forms.css
@@ -12,6 +12,7 @@ Library for consistent form layout.
 
 .form {
 	--form--spacing: 1rem;
+	--form--fieldset-gap: 2rem;
 
 	margin-top: var(--form--spacing);
 	margin-bottom: var(--form--spacing);
@@ -40,4 +41,85 @@ Library for consistent form layout.
 
 .form__extra-links {
 	font-size: 0.9rem;
+}
+
+.fieldset {
+	margin-bottom: 2rem;
+	display: flex;
+	flex-direction: column;
+	gap: var(--form--fieldset-gap);
+	transition-property: gap;
+}
+
+.fieldset:last-child {
+	margin-bottom: 0;
+}
+
+@media screen and (min-width: 769px) {
+	.form {
+		--form--fieldset-gap: 5rem;
+		--form--fieldset-header-width: 50%;
+		--form--fieldset-fields-width: 50%;
+	}
+
+	.fieldset {
+		flex-direction: row;
+	}
+
+	.fieldset__header {
+		flex-basis: var(--form--fieldset-header-width);
+	}
+
+	.fieldset__fields {
+		flex-basis: var(--form--fieldset-fields-width);
+	}
+
+	.form__align-with-fields {
+		margin-left: calc(var(--form--fieldset-header-width) + var(--form--fieldset-gap) / 2);
+	}
+}
+
+.fieldset__title {
+	font-size: 1.2rem;
+	font-weight: var(--font-weight-medium);
+	margin-bottom: 1rem;
+}
+
+.fieldset__fields {
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+}
+
+.field__wrapper--input label {
+	display: block;
+	font-weight: var(--font-weight-medium);
+	margin-bottom: 0.5rem;
+}
+
+.field__wrapper--input input,
+.field__wrapper--input textarea,
+.field__wrapper--input select {
+	width: 100%;
+}
+
+.field__description {
+	font-size: 0.9rem;
+	color: gray;
+	margin-top: 0.5rem;
+}
+
+.checkbox {
+	display: flex;
+	gap: 0.5rem;
+	align-items: start;
+}
+
+.checkbox .field_with_errors {
+	display: flex;
+	align-items: start;
+}
+
+.checkbox input {
+	margin-top: calc(((1rem * 1.5) - 1rem) / 2);
 }

--- a/app/assets/stylesheets/variables.css
+++ b/app/assets/stylesheets/variables.css
@@ -104,6 +104,16 @@
 	--color--green-9: #cdf4bf;
 	--color--green-10: #dff8d4;
 	--color--green-11: #eefbe9;
+	--color--red-1: #7F1D1D;
+	--color--red-2: #991B1B;
+	--color--red-3: #B91C1C;
+	--color--red-4: #DC2626;
+	--color--red-5: #EF4444;
+	--color--red-6: #F87171;
+	--color--red-7: #FCA5A5;
+	--color--red-8: #FECACA;
+	--color--red-9: #FEE2E2;
+	--color--red-10: #FEF2F2;
 
 	--color--brand--tan: var(--color--tan-6);
 	--color--brand--blue: var(--color--blue-6);
@@ -113,4 +123,7 @@
 	--color--mood--success: var(--color--green-4);
 	--color--mood--success--contrast: white;
 	--color--mood--success--hover: var(--color--green-3);
+	--color--mood--error: var(--color--red-4);
+	--color--mood--error--contrast: white;
+	--color--mood--error--hover: var(--color--red-3);
 }

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -1,0 +1,48 @@
+class ApplicantsController < ApplicationController
+  sig { void }
+  def new
+    @applicant ||= Applicant.new
+  end
+
+  # A class representing the allowed params into the `create` endpoint
+  class CreateApplicantParams < T::Struct
+    const :name, String
+    const :email, String
+    const :affiliation, T.nilable(String)
+    const :primary_role, T.nilable(String)
+    const :use_case, T.nilable(String)
+    const :accepted_terms, String
+  end
+
+  sig { void }
+  def create
+    # Verify the types of the values provided in the request.
+    # TODO: Pass the output of this to `Applicant.create!()`
+    TypedParams[CreateApplicantParams].new.extract!(applicant_params)
+
+    @applicant = Applicant.new(applicant_params)
+
+    if @applicant.save
+      redirect_to new_applicant_thanks_path
+    else
+      flash.now[:error] = "We weren’t able to save your application. Please be sure to fill out all required fields."
+      render :new, status: :unprocessable_entity
+    end
+end
+
+  sig { void }
+  def thanks; end
+
+private
+
+  def applicant_params
+    params.require(:applicant).permit(
+      :name,
+      :email,
+      :affiliation,
+      :primary_role,
+      :use_case,
+      :accepted_terms
+    )
+  end
+end

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -25,7 +25,7 @@ class ApplicantsController < ApplicationController
     if @applicant.save
       redirect_to new_applicant_thanks_path
     else
-      flash.now[:error] = "We weren’t able to save your application. Please be sure to fill out all required fields."
+      flash.now[:error] = "We weren’t able to save your application. Please check the form below for errors."
       render :new, status: :unprocessable_entity
     end
 end

--- a/app/helpers/applicants_helper.rb
+++ b/app/helpers/applicants_helper.rb
@@ -1,0 +1,2 @@
+module ApplicantsHelper
+end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,0 +1,11 @@
+module FormHelper
+  def errors_for_field(model, field, options = {})
+    options = {
+      full: true,
+    }.merge(options)
+    if model.errors.has_key? field
+      message_method = options[:full] ? "full_messages_for" : "messages_for"
+      render partial: "partials/errors_for_field", locals: { messages: model.errors.send(message_method, field) }
+    end
+  end
+end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,0 +1,36 @@
+class Applicant < ApplicationRecord
+  # A boolean value for terms acceptance stored in the database isn't good enough for auditing,
+  # but a boolean attribute is useful for magic form composition and validation. Thus, we use a
+  # non-database-backed attribute until model creation time, when we generate the timestamp and
+  # version number for database storage.
+  attr_accessor :accepted_terms
+
+  validates :name, presence: true
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :accepted_terms, acceptance: { message: "Terms must be accepted." }
+
+  after_initialize :map_terms_database_values_to_accessor
+  before_create :map_terms_accessor_to_database_values
+
+private
+
+  # The `accepted_terms` attribute should reflect the current status of the database (or itself,
+  # if already set).
+  sig { void }
+  def map_terms_database_values_to_accessor
+    has_accepted_current_terms = self.accepted_terms_at.present? &&
+      self.accepted_terms_version == TermsOfService::CURRENT_VERSION
+
+    self.accepted_terms ||= has_accepted_current_terms
+  end
+
+  # Proxy the boolean acceptance of terms to the actual data we need to store on the record.
+  # See the note above on the accessor for why.
+  sig { void }
+  def map_terms_accessor_to_database_values
+    if self.accepted_terms
+      self.accepted_terms_at = Time.now
+      self.accepted_terms_version = TermsOfService::CURRENT_VERSION
+    end
+  end
+end

--- a/app/views/applicants/new.html.erb
+++ b/app/views/applicants/new.html.erb
@@ -1,0 +1,76 @@
+<% @title_tag = "Request access" %>
+
+<%= form_with(
+		model: @applicant,
+		url: applicants_path,
+		class: "form"
+	) do |f| %>
+	<fieldset class="fieldset">
+		<div class="fieldset__header">
+			<div class="fieldset__title">
+				Request access
+			</div>
+			<div class="fieldset__description">
+				<p>Access to the site requires approval by the Duke Reporters’ Lab team. Approval is usually determined within [X DURATION, e.g. “three days”]. The more detail you can provide about who you are and how you want to use the data, the better. If you have any questions, please get in touch.</p>
+			</div>
+		</div>
+		<div class="fieldset__fields">
+				<div class="field__wrapper--input">
+					<%= f.label(
+						:name,
+						"Your name *") %>
+					<%= f.text_field(
+						:name,
+						required: true) %>
+				</div>
+				<div class="field__wrapper--input">
+					<%= f.label(
+						:email,
+						"Email address *") %>
+					<%= f.email_field(
+						:email,
+						required: true) %>
+					<div class="field__description">You’ll need to confirm this email address before we process your application.</div>
+				</div>
+				<div class="field__wrapper--input">
+					<%= f.label :affiliation do %>
+						Organization affiliation <span style="font-weight:normal">(if any)</span>
+					<% end %>
+					<%= f.text_field :affiliation %>
+					<div class="field__description">If you will be using this data primarily on behalf of an organization — such as your employer or university — please let us know.</div>
+				</div>
+				<div class="field__wrapper--input">
+					<%= f.label(
+						:primary_role,
+						"What is your primary role?") %>
+					<%= f.text_field(
+						:primary_role,
+						placeholder:
+						"Fact-checker, researcher, etc.") %>
+				</div>
+				<div class="field__wrapper--input">
+					<%= f.label(
+						:use_case,
+						"How do you plan to use the data?") %>
+					<%= f.text_area(
+						:use_case,
+						size: "50x3") %>
+				</div>
+				<div class="field__wrapper--checkboxes">
+					<div class="checkbox">
+						<%= f.check_box(
+							:accepted_terms,
+							required: true ) %>
+						<%= f.label :accepted_terms do %>
+							Accept the terms and conditions
+						<% end %>
+					</div>
+				</div>
+		</div>
+	</fieldset>
+	<div class="form__align-with-fields">
+		<%= f.submit(
+			"Submit request",
+			class: "btn btn--submit") %>
+	</div>
+<% end %>

--- a/app/views/applicants/new.html.erb
+++ b/app/views/applicants/new.html.erb
@@ -22,6 +22,9 @@
 					<%= f.text_field(
 						:name,
 						required: true) %>
+					<%= errors_for_field(
+						@applicant,
+						:name) %>
 				</div>
 				<div class="field__wrapper--input">
 					<%= f.label(
@@ -30,6 +33,9 @@
 					<%= f.email_field(
 						:email,
 						required: true) %>
+					<%= errors_for_field(
+						@applicant,
+						:email) %>
 					<div class="field__description">You’ll need to confirm this email address before we process your application.</div>
 				</div>
 				<div class="field__wrapper--input">
@@ -63,6 +69,10 @@
 							required: true ) %>
 						<%= f.label :accepted_terms do %>
 							Accept the terms and conditions
+							<%= errors_for_field(
+								@applicant,
+								:accepted_terms,
+								full: false) %>
 						<% end %>
 					</div>
 				</div>

--- a/app/views/applicants/thanks.html.erb
+++ b/app/views/applicants/thanks.html.erb
@@ -1,0 +1,6 @@
+<% @title_tag = "Thanks" %>
+
+<div style="margin:4rem 0">
+	<p>Thanks for your application. We’ll be in touch.</p>
+</div>
+

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -75,6 +75,7 @@
             </li>
           <% end %>
         <% else %>
+          <li><%= link_to "Request access", new_applicant_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
           <li><%= link_to "Log in", new_user_session_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
         <% end %>
       </ul>

--- a/app/views/partials/_errors_for_field.html.erb
+++ b/app/views/partials/_errors_for_field.html.erb
@@ -1,0 +1,5 @@
+<ul class="field__error-messages">
+	<% messages.each do |message| %>
+		<li class="field__error-message"><%= message %></li>
+	<% end %>
+</ul>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,7 +1,8 @@
 <div class="box box--sm box--miniform">
 	<p>
 		To access Zenodotus, please log in below.
-		Don’t have an account? You’ll be able to request one soon.
+		Don’t have an account?
+		<%= link_to "Request one here", new_applicant_path %>
 	</p>
 	<%= form_for(
 				resource,

--- a/config/initializers/terms_of_service.rb
+++ b/config/initializers/terms_of_service.rb
@@ -1,0 +1,3 @@
+class TermsOfService
+  CURRENT_VERSION = DateTime.parse("2022-08-22")
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,11 @@ Rails.application.routes.draw do
 
   root "archive#index"
 
+  # TODO: Mount `/apply/new` at `/apply` so this redirect isn't necessary.
+  get "/apply", to: redirect("/apply/new"), as: :applicant
+  get "/apply/thanks", to: "applicants#thanks", as: :new_applicant_thanks
+  resources :applicants, path: "/apply", only: [:new, :create]
+
   get "/archive/add", to: "archive#add"
   post "/archive/add", to: "archive#submit_url"
   get "/archive/download", to: "archive#export_archive_data", as: "archive_download"

--- a/db/migrate/20220808225818_create_applicants.rb
+++ b/db/migrate/20220808225818_create_applicants.rb
@@ -1,0 +1,14 @@
+class CreateApplicants < ActiveRecord::Migration[7.0]
+  def change
+    create_table :applicants, id: :uuid do |t|
+      t.string   :name, null: false
+      t.string   :email, null: false
+      t.string   :affiliation
+      t.string   :primary_role
+      t.text     :use_case
+      t.datetime :accepted_terms_at
+      t.datetime :accepted_terms_version
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_16_162441) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_08_225818) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -28,6 +28,18 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_16_162441) do
     t.datetime "updated_at", null: false
     t.index ["hashed_api_key"], name: "index_api_keys_on_hashed_api_key"
     t.index ["user_id"], name: "index_api_keys_on_user_id"
+  end
+
+  create_table "applicants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "affiliation"
+    t.string "primary_role"
+    t.text "use_case"
+    t.datetime "accepted_terms_at"
+    t.datetime "accepted_terms_version"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "archive_entities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/controllers/applicants_controller_test.rb
+++ b/test/controllers/applicants_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ApplicantsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/applicants.yml
+++ b/test/fixtures/applicants.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+jane:
+  name: Jane Doe
+  email: jane@example.com
+  affiliation: Test Organization
+  primary_role: Fact-Checker
+  use_case: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  accepted_terms_at: <%= Time.now %>
+  accepted_terms_version: <%= TermsOfService::CURRENT_VERSION %>
+
+expired_terms:
+  name: Jane Doe
+  email: jane@example.com
+  affiliation: Test Organization
+  primary_role: Fact-Checker
+  use_case: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  accepted_terms_at: <%= Time.now %>
+  accepted_terms_version: <%= Date.parse("2022-08-01") %>

--- a/test/models/applicant_test.rb
+++ b/test/models/applicant_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class ApplicantTest < ActiveSupport::TestCase
+  def setup
+    @applicant = Applicant.new
+  end
+
+  test "requires name, email, and acceptance" do
+    assert_not @applicant.valid?
+
+    @applicant.name = "John Doe"
+    assert_not @applicant.valid?
+
+    @applicant.email = "john@example.com"
+    assert_not @applicant.valid?
+
+    @applicant.accepted_terms = true
+    assert @applicant.valid?
+
+    @applicant.accepted_terms = false
+    assert_not @applicant.valid?
+  end
+
+  test "cannot create an applicant without accepting terms" do
+    assert_raises ActiveRecord::RecordInvalid do
+      Applicant.create!({
+        name: "John Doe",
+        email: "john@example.com"
+      })
+    end
+  end
+
+  # This test ensures that if the model has its terms-acceptance database attributes populated
+  # properly, that the model itself sets the `accepted_terms` attribute accordingly during init.
+  test "can convert terms-acceptance attributes from database" do
+    assert applicants(:jane).accepted_terms
+  end
+
+  # This test ensures that if the user's accepted terms don't match the current version, then they
+  # have not "accepted the terms".
+  test "must have accepted most recent terms" do
+    assert_not applicants(:expired_terms).accepted_terms
+  end
+
+  # If the user has accepted terms, then they are initially valid.
+  # If they attempt to unaccept, their model should not be valid.
+  test "cannot un-accept terms" do
+    jane = applicants(:jane)
+    assert jane.valid?
+
+    assert_raises ActiveRecord::RecordInvalid do
+      jane.update!({
+        accepted_terms: false
+      })
+    end
+  end
+
+  test "can edit applicant without triggering acceptance errors" do
+    jane = applicants(:jane)
+
+    assert_nothing_raised do
+      jane.update!({
+        name: "Janes Doe"
+      })
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Request Access page to the site. It's not full-featured, as it doesn't yet require email confirmation or allow the user to close the loop on creating a user account, but it's the first step.

**Testing:**
- Run the migrations
- Check tests with `rails t test/models/applicant_test.rb`
- Start the app with `./bin/dev`
- Go to the "Request access" link in the navbar
- Fill out the application and submit

**Notes:**
- I used the `required` attribute on fields that are required, which means the browser will stop the user from submitting a form without them. You can flip them to `required: false` to see Rails validation in action.
- The "Thanks" page is unstyled. That's because it's going to quickly be replaced with the "You must confirm your email" page anyway.
- The language is still being worked on via the Google content doc, thus the placeholders like `[X DURATION]`.

![request-access](https://user-images.githubusercontent.com/4731/186035004-e2457dfd-d745-4452-b948-ca7024b90f4c.png)

Closes #295