### PR TITLE
Add country to application form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -170,3 +170,7 @@ gem "aws-sdk-s3"
 
 # This enables reverse image and video searching
 gem "zelkova"
+
+# Generates a country selector for forms
+# Also adds and uses the `countries` gem
+gem "country_select", "~> 8.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,10 @@ GEM
     concurrent-ruby (1.1.10)
     connection_pool (2.2.5)
     content_disposition (1.0.0)
+    countries (5.1.2)
+      sixarm_ruby_unaccent (~> 1.1)
+    country_select (8.0.0)
+      countries (~> 5.0)
     crass (1.0.6)
     cssbundling-rails (1.1.0)
       railties (>= 6.0.0)
@@ -364,6 +368,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sixarm_ruby_unaccent (1.2.0)
     sorbet (0.5.9914)
       sorbet-static (= 0.5.9914)
     sorbet-coerce (0.5.0)
@@ -455,6 +460,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara (>= 3.26)
+  country_select (~> 8.0)
   cssbundling-rails
   devise (~> 4.8.0)
   dotenv-rails

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -8,6 +8,7 @@ class ApplicantsController < ApplicationController
   class CreateApplicantParams < T::Struct
     const :name, String
     const :email, String
+    const :country, T.nilable(String)
     const :affiliation, T.nilable(String)
     const :primary_role, T.nilable(String)
     const :use_case, T.nilable(String)
@@ -39,6 +40,7 @@ private
     params.require(:applicant).permit(
       :name,
       :email,
+      :country,
       :affiliation,
       :primary_role,
       :use_case,

--- a/app/views/applicants/new.html.erb
+++ b/app/views/applicants/new.html.erb
@@ -56,6 +56,17 @@
 				</div>
 				<div class="field__wrapper--input">
 					<%= f.label(
+						:country,
+						"Where are you located?") %>
+					<%= f.country_select(
+						:country,
+						include_blank: true) %>
+					<%= errors_for_field(
+						@applicant,
+						:country) %>
+				</div>
+				<div class="field__wrapper--input">
+					<%= f.label(
 						:use_case,
 						"How do you plan to use the data?") %>
 					<%= f.text_area(

--- a/db/migrate/20220830181411_add_country_to_applicant.rb
+++ b/db/migrate/20220830181411_add_country_to_applicant.rb
@@ -1,0 +1,5 @@
+class AddCountryToApplicant < ActiveRecord::Migration[7.0]
+  def change
+    add_column :applicants, :country, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_24_134550) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_30_181411) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -40,6 +40,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_24_134550) do
     t.datetime "accepted_terms_version"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "country"
   end
 
   create_table "archive_entities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/fixtures/applicants.yml
+++ b/test/fixtures/applicants.yml
@@ -3,6 +3,7 @@
 jane:
   name: Jane Doe
   email: jane@example.com
+  country: US
   affiliation: Test Organization
   primary_role: Fact-Checker
   use_case: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -12,6 +13,7 @@ jane:
 expired_terms:
   name: Jane Doe
   email: jane@example.com
+  country: US
   affiliation: Test Organization
   primary_role: Fact-Checker
   use_case: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.


### PR DESCRIPTION
This PR adds the Country field to the Request Access application form, as "Where are you located?":

<img width="1278" alt="request-access" src="https://user-images.githubusercontent.com/4731/187519763-0494cb6d-de65-413a-9d55-14aa422860e2.png">

To do so, it uses the [`country_select`](https://github.com/countries/country_select) gem.

**Testing**
- 🚨 `bundle install`
- 🚨 `rails db:migrate`
- Run tests: `rails t test/models/applicant_test.rb`
- Start the app and go to the Request Access page. Make sure you can create an applicant both with and without a country selected. Wouldn't hurt to check the database manually to be sure `country` contains the expected country code.

Closes #323