### PR TITLE
Make "use case" field required on Request Access form

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -7,6 +7,7 @@ class Applicant < ApplicationRecord
 
   validates :name, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :use_case, presence: true
   validates :accepted_terms, acceptance: { message: "Terms must be accepted." }
 
   after_initialize :map_terms_database_values_to_accessor

--- a/app/views/applicants/new.html.erb
+++ b/app/views/applicants/new.html.erb
@@ -39,6 +39,18 @@
 					<div class="field__description">You’ll need to confirm this email address before we process your application.</div>
 				</div>
 				<div class="field__wrapper--input">
+					<%= f.label(
+						:use_case,
+						"How do you plan to use the data? *") %>
+					<%= f.text_area(
+						:use_case,
+						size: "50x3",
+						required: true) %>
+					<%= errors_for_field(
+						@applicant,
+						:use_case) %>
+				</div>
+				<div class="field__wrapper--input">
 					<%= f.label :affiliation do %>
 						Organization affiliation <span style="font-weight:normal">(if any)</span>
 					<% end %>
@@ -64,18 +76,6 @@
 					<%= errors_for_field(
 						@applicant,
 						:country) %>
-				</div>
-				<div class="field__wrapper--input">
-					<%= f.label(
-						:use_case,
-						"How do you plan to use the data? *") %>
-					<%= f.text_area(
-						:use_case,
-						size: "50x3",
-						required: true) %>
-					<%= errors_for_field(
-						@applicant,
-						:use_case) %>
 				</div>
 				<div class="field__wrapper--checkboxes">
 					<div class="checkbox">

--- a/app/views/applicants/new.html.erb
+++ b/app/views/applicants/new.html.erb
@@ -68,10 +68,14 @@
 				<div class="field__wrapper--input">
 					<%= f.label(
 						:use_case,
-						"How do you plan to use the data?") %>
+						"How do you plan to use the data? *") %>
 					<%= f.text_area(
 						:use_case,
-						size: "50x3") %>
+						size: "50x3",
+						required: true) %>
+					<%= errors_for_field(
+						@applicant,
+						:use_case) %>
 				</div>
 				<div class="field__wrapper--checkboxes">
 					<div class="checkbox">

--- a/app/views/applicants/new.html.erb
+++ b/app/views/applicants/new.html.erb
@@ -83,7 +83,7 @@
 							:accepted_terms,
 							required: true ) %>
 						<%= f.label :accepted_terms do %>
-							Accept the terms and conditions
+							Accept the terms and conditions *
 							<%= errors_for_field(
 								@applicant,
 								:accepted_terms,

--- a/test/models/applicant_test.rb
+++ b/test/models/applicant_test.rb
@@ -5,13 +5,16 @@ class ApplicantTest < ActiveSupport::TestCase
     @applicant = Applicant.new
   end
 
-  test "requires name, email, and acceptance" do
+  test "requires all required fields to be set" do
     assert_not @applicant.valid?
 
     @applicant.name = "John Doe"
     assert_not @applicant.valid?
 
     @applicant.email = "john@example.com"
+    assert_not @applicant.valid?
+
+    @applicant.use_case = "Journalism and fact-checking."
     assert_not @applicant.valid?
 
     @applicant.accepted_terms = true


### PR DESCRIPTION
This PR makes the "How do you plan to use the data?" field on the Request Access form required, and moves it to be with the other required fields:

<img width="1271" alt="request-access" src="https://user-images.githubusercontent.com/4731/187526597-7303b4a8-23c8-420d-995c-d30f3ac1ec6c.png">

As shown there, it also adds the "required" asterisk to the "Accept the terms and conditions" checkbox, which was already required functionally.

**Testing:**
- Make sure you can't submit the form without entering a use case (stretch testing: disable `required: false` in the HTML template to trigger the Rails validation)

Closes #324
Closes #326