### PR TITLE
Remove assert_nothing_raised applicant test

### DIFF
--- a/test/models/applicant_test.rb
+++ b/test/models/applicant_test.rb
@@ -58,10 +58,8 @@ class ApplicantTest < ActiveSupport::TestCase
   test "can edit applicant without triggering acceptance errors" do
     jane = applicants(:jane)
 
-    assert_nothing_raised do
-      jane.update!({
-        name: "Janes Doe"
-      })
-    end
+    assert jane.update({
+      name: "Janes Doe"
+    })
   end
 end


### PR DESCRIPTION
This PR does a tiny bit of work toward #328 by replacing an `assert_nothing_raised` test on the `Applicant` model with a standard assertion. See the related issue for some of the reasoning.

**Testing:**
- `rails t test/models/applicant_test.rb`

Affects #328