### PR TITLE
Improve applicant fixtures

### DIFF
--- a/test/fixtures/applicants.yml
+++ b/test/fixtures/applicants.yml
@@ -1,6 +1,6 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-jane:
+new:
   name: Jane Doe
   email: jane@example.com
   use_case: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/test/fixtures/applicants.yml
+++ b/test/fixtures/applicants.yml
@@ -3,9 +3,6 @@
 jane:
   name: Jane Doe
   email: jane@example.com
-  country: US
-  affiliation: Test Organization
-  primary_role: Fact-Checker
   use_case: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
   accepted_terms_at: <%= Time.now %>
   accepted_terms_version: <%= TermsOfService::CURRENT_VERSION %>
@@ -15,9 +12,6 @@ jane:
 expired_terms:
   name: Jane Doe
   email: jane@example.com
-  country: US
-  affiliation: Test Organization
-  primary_role: Fact-Checker
   use_case: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
   accepted_terms_at: <%= Time.now %>
   accepted_terms_version: <%= Date.parse("2022-08-01") %>

--- a/test/models/applicant_test.rb
+++ b/test/models/applicant_test.rb
@@ -36,7 +36,7 @@ class ApplicantTest < ActiveSupport::TestCase
   # This test ensures that if the model has its terms-acceptance database attributes populated
   # properly, that the model itself sets the `accepted_terms` attribute accordingly during init.
   test "can convert terms-acceptance attributes from database" do
-    assert applicants(:jane).accepted_terms
+    assert applicants(:new).accepted_terms
   end
 
   # This test ensures that if the user's accepted terms don't match the current version, then they
@@ -48,45 +48,45 @@ class ApplicantTest < ActiveSupport::TestCase
   # If the user has accepted terms, then they are initially valid.
   # If they attempt to unaccept, their model should not be valid.
   test "cannot un-accept terms" do
-    jane = applicants(:jane)
-    assert jane.valid?
+    new_applicant = applicants(:new)
+    assert new_applicant.valid?
 
     assert_raises ActiveRecord::RecordInvalid do
-      jane.update!({
+      new_applicant.update!({
         accepted_terms: false
       })
     end
   end
 
   test "can edit applicant without triggering acceptance errors" do
-    jane = applicants(:jane)
+    new_applicant = applicants(:new)
 
-    assert jane.update({
+    assert new_applicant.update({
       name: "Janes Doe"
     })
   end
 
   test "can determine confirmation status correctly" do
-    jane = applicants(:jane)
+    new_applicant = applicants(:new)
 
-    assert_not jane.confirmed?
+    assert_not new_applicant.confirmed?
 
-    jane.confirm
+    new_applicant.confirm
 
-    assert jane.confirmed?
+    assert new_applicant.confirmed?
   end
 
   test "does not reconfirm if already confirmed" do
-    jane = applicants(:jane)
+    new_applicant = applicants(:new)
 
-    assert jane.confirm
+    assert new_applicant.confirm
 
     # Cache this timestamp so we can compare against it later
-    confirmed_at = jane.confirmed_at
+    confirmed_at = new_applicant.confirmed_at
 
-    assert_not jane.confirm
+    assert_not new_applicant.confirm
 
     # The timestamps should remain equal
-    assert_equal confirmed_at, jane.confirmed_at
+    assert_equal confirmed_at, new_applicant.confirmed_at
   end
 end


### PR DESCRIPTION
This PR makes some minor changes to our `Applicant` fixtures (and some model comments), basically some tidying up in preparation for future changes in #271.

- Renames the too-cute `jane` fixture to simply `new` to match its role as a fresh new applicant
- Removes unused optional attributes from fixture until we need them (to cut down on boilerplate)
- Improves the wording of some `Applicant` model method descriptions

This is a lightweight PR that I'm going to merge myself without approval.