### PR TITLE
Enable change-of-email confirmation for users

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -44,7 +44,7 @@ class AccountsController < ApplicationController
     current_user.email = typed_params.email
     current_user.save
     respond_to do |format|
-      flash.now[:alert] = "Email updated."
+      flash.now[:alert] = "We just sent a confirmation message to the email address you provided. Please check your inbox and follow the confirmation link in the message."
       format.turbo_stream { render turbo_stream: [
         turbo_stream.replace("flash", partial: "layouts/flashes/turbo_flashes", locals: { flash: flash }),
       ] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,11 +8,10 @@ class User < ApplicationRecord
   has_many :text_searches, dependent: :destroy
 
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  # :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :trackable, :lockable # , :confirmable
-  # TODO: re-enable :confirmable after mailer is set up
+         :trackable, :lockable, :confirmable
 
   sig { returns(T::Boolean) }
   def super_admin?

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -30,7 +30,7 @@ Devise.setup do |config|
   # config.mailer = 'Devise::Mailer'
 
   # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'ActionMailer::Base'
+  config.parent_mailer = "ApplicationMailer"
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,10 +15,15 @@ Rails.application.routes.draw do
   # them in this configuration block, that would be amazing.)
   devise_for :users,
              skip: :all,
-             only: [:sessions, :registrations],
+             only: [
+              :sessions,
+              :registrations,
+              :confirmations
+             ],
              controllers: {
                sessions: "users/sessions",
-               registrations: "users/registrations"
+               registrations: "users/registrations",
+               confirmations: "users/confirmations"
              }
 
   root "archive#index"


### PR DESCRIPTION
This PR enables email confirmation for users changing their email address. This is a necessary prerequisite for cleanly converting applicants (which require confirmed emails) to users, and is good form besides.

**Testing:**
- Start Rails and Sidekiq
- Log in and go to your user settings screen (http://localhost:3000/account)
- Update your email address to a new one (that you actually have access to)
- ✅ See a flash that tells you to go check your email
- ✅ Verify (in console/database) that your email has not _actually_ changed yet
- Go check your email! Click the confirmation link inside. (Ignore the email design and language. This is Devise boilerplate that we will customize.)
- ✅ Clicking the link should confirm the email change; verify in console/database

Issue #271