### PR TITLE
Create a user from a given applicant

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,4 +1,7 @@
 class Applicant < ApplicationRecord
+  # This relationship is optional because not all applicants will become users.
+  belongs_to :user, optional: true
+
   # A boolean value for terms acceptance stored in the database isn't good enough for auditing,
   # but a boolean attribute is useful for magic form composition and validation. Thus, we use a
   # non-database-backed attribute until model creation time, when we generate the timestamp and

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
   has_many :image_searches, dependent: :destroy
   has_many :text_searches, dependent: :destroy
 
+  has_one :applicant, dependent: :destroy
+
   # Include default devise modules. Others available are:
   # :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,27 @@ class User < ApplicationRecord
   def super_admin?
     self.super_admin
   end
+
+  # Create a User from an approved Applicant.
+  #
+  # BUG: This should be `applicant: Applicant`, but that throws an error.
+  #      We are temporarily using this absurdly permissive sig that works.
+  #      See: https://github.com/TechAndCheck/zenodotus/issues/342
+  sig { params(applicant: Object).returns(User) }
+  def self.create_from_applicant(applicant)
+    raise ApplicantNotApprovedError unless applicant.approved?
+
+    self.create!({
+      applicant: applicant,
+      email: applicant.email,
+      # The user will have to change their password immediately. This is just to pass validation.
+      password: Devise.friendly_token,
+      # The user inherits the applicant's email confirmation.
+      confirmation_token: applicant.confirmation_token,
+      confirmed_at: applicant.confirmed_at,
+      confirmation_sent_at: applicant.confirmation_sent_at
+    })
+  end
 end
+
+class User::ApplicantNotApprovedError < StandardError; end

--- a/db/migrate/20220912215054_add_user_to_applicants.rb
+++ b/db/migrate/20220912215054_add_user_to_applicants.rb
@@ -1,0 +1,5 @@
+class AddUserToApplicants < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :applicants, :user, index: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_08_221614) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_12_215054) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -49,7 +49,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_08_221614) do
     t.datetime "reviewed_at", precision: nil
     t.text "review_note"
     t.text "review_note_internal"
+    t.uuid "user_id"
     t.index ["confirmation_token"], name: "index_applicants_on_confirmation_token", unique: true
+    t.index ["user_id"], name: "index_applicants_on_user_id"
   end
 
   create_table "archive_entities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,4 +1,31 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
+  test "can associate a user with an applicant" do
+    user = users(:user1)
+    applicant = applicants(:approved)
+
+    user.update(applicant: applicant)
+
+    assert_equal applicant, user.applicant
+  end
+
+  test "destroying user destroys applicant too" do
+    user = users(:user1)
+    applicant = applicants(:approved)
+
+    user.update(applicant: applicant)
+
+    applicant_id = applicant.id
+    user_id = user.id
+
+    user.destroy
+
+    assert_raises ActiveRecord::RecordNotFound do
+      User.find(user_id)
+    end
+    assert_raises ActiveRecord::RecordNotFound do
+      Applicant.find(applicant_id)
+    end
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -28,4 +28,25 @@ class UserTest < ActiveSupport::TestCase
       Applicant.find(applicant_id)
     end
   end
+
+  test "can create user from approved applicant" do
+    approved_applicant = applicants(:approved)
+
+    assert User.create_from_applicant(approved_applicant)
+  end
+
+  test "cannot create user from applicant unless approved" do
+    rejected_applicant = applicants(:rejected)
+
+    assert_raises User::ApplicantNotApprovedError do
+      User.create_from_applicant(rejected_applicant)
+    end
+  end
+
+  test "inherits applicant confirmation token" do
+    approved_applicant = applicants(:approved)
+    user = User.create_from_applicant(approved_applicant)
+
+    assert_equal approved_applicant.confirmation_token, user.confirmation_token
+  end
 end


### PR DESCRIPTION
_This PR ladders off #343._

This PR adds the ability to create a user given an approved applicant. It's step 2 on our way to #271.

⚠️ Note that you won't be able to actually log in as this user just yet (unless you are very good at guessing passwords). The next PR will add the notification email to the user and the ability for them to change their password.

**Testing:**
- Prerequisite: A **new applicant** whose email **has been confirmed,** and which email **doesn't match an existing user**.
- 🚨 `rails db:migrate`
- ✅ `rails t`
- `rails c`
- Find the prerequisite applicant: `a = Applicant.find(id)`
- Create the accompany user: `u = User.create_from_applicant(a)`
- ✅ It should work! (Though see ⚠️ note above.)
- Destroy the user: `u.destroy`
- ✅ The original applicant **should be destroyed** as well. (This is a change from the initial behavior, see conversation below.)

**Test failing cases:**
- Try to create a user from an applicant whose email matches an existing user's: raises `ActiveRecord::RecordInvalid`
- Try to create a user from an applicant that's not confirmed: raises `User::ApplicantNotApprovedError`

Issue #271