### PR TITLE
Move YoutubePost duration conversion out of Zenodotus

### DIFF
--- a/app/models/sources/youtube_post.rb
+++ b/app/models/sources/youtube_post.rb
@@ -66,18 +66,6 @@ class Sources::YoutubePost < ApplicationRecord
     create_from_youtube_archiver_hash(youtube_archiver_videos, user)
   end
 
-  # Find the number of seconds in a YouTube duration string
-  # @ params duration_string [String] A string following the pattern PT#H#M#S, where # is an integer
-  # @ returns [Integer] Number of seconds
-  sig { params(duration_string: String).returns(Integer) }
-  def self.find_length_of_youtube_video(duration_string)
-    if /PT((\d+)H)?((\d+)M)?((\d+)S)?/ =~ duration_string
-      $2.to_i * 3600 + $4.to_i * 60 + $6.to_i
-    else
-      0
-    end
-  end
-
   # Create a +ArchiveItem+ from a +Forki::Post+
   #
   # @!scope class
@@ -122,7 +110,7 @@ class Sources::YoutubePost < ApplicationRecord
         num_comments:      youtube_archiver_video["num_comments"],
         posted_at:         youtube_archiver_video["created_at"],
         language:          youtube_archiver_video["language"],
-        duration:          find_length_of_youtube_video(youtube_archiver_video["duration"]),
+        duration:          youtube_archiver_video["duration"],
         live:              youtube_archiver_video["live"],
         author:            youtube_channel,
         made_for_kids:     youtube_archiver_video["made_for_kids"],

--- a/test/mocks/data/youtube_posts.json
+++ b/test/mocks/data/youtube_posts.json
@@ -22,7 +22,7 @@
             "view_count": "20478661"
           },
           "created_at": "2022-08-01T19:00:25Z",
-          "duration": "PT10S",
+          "duration": 10,
           "language": "en-US",
           "live": false,
           "made_for_kids": false,
@@ -60,7 +60,7 @@
             "view_count": "20485540"
           },
           "created_at": "2022-03-22T18:00:22Z",
-          "duration": "PT9S",
+          "duration": 9,
           "language": "en-US",
           "live": false,
           "made_for_kids": false,
@@ -98,7 +98,7 @@
             "view_count": "5893527017"
           },
           "created_at": "2022-02-21T13:41:16Z",
-          "duration": "PT27S",
+          "duration": 27,
           "language": null,
           "live": false,
           "made_for_kids": false,


### PR DESCRIPTION
This PR moves some duration attribute formatting logic out of Zenodotus and into the `YoutubeArchiver` scraper gem. 

See https://github.com/TechAndCheck/YoutubeArchiver/pull/10. Closes https://github.com/TechAndCheck/zenodotus/issues/341

# Testing instructions
`rake`