### PR TITLE
Remove `assert_equal` comparison for nil values in FacebookPostTest

### DIFF
--- a/test/models/facebook_post_test.rb
+++ b/test/models/facebook_post_test.rb
@@ -27,17 +27,19 @@ class FacebookPostTest < ActiveSupport::TestCase
     assert_not_nil archive_item
     assert_kind_of ArchiveItem, archive_item
 
-    assert_equal @@forki_image_post.first["post"]["text"], archive_item.facebook_post.text
     assert_equal @@forki_image_post.first["post"]["id"], archive_item.facebook_post.facebook_id
     assert_equal @@forki_image_post.first["id"], archive_item.service_id
     assert_equal @@forki_image_post.first["post"]["url"], archive_item.facebook_post.url
     assert_equal Time.at(@@forki_image_post.first["post"]["created_at"]).utc.strftime("%FT%T%:z"), archive_item.facebook_post.posted_at.strftime("%FT%T%:z")
 
+    assert_nil @@forki_image_post.first["post"]["text"]
+    assert_nil archive_item.facebook_post.text
+
     assert_not_nil archive_item.facebook_post.author
+    assert_not_nil archive_item.facebook_post.images
+
     assert archive_item.facebook_post.number_of_likes.positive?
     assert archive_item.facebook_post.number_of_love_reactions.positive?
-
-    assert_not_nil archive_item.facebook_post.images
   end
 
   test "can archive Facebook post from url" do


### PR DESCRIPTION
Closes https://github.com/TechAndCheck/zenodotus/issues/334

In `FacebookPostTest.can_create_Facebook_post_test`, we use `assert_equal` to compare two null attributes (the post in the example has no text)
https://github.com/TechAndCheck/zenodotus/blob/20047363bba63f3c5a7bc02455fafa40fbabe791/test/models/facebook_post_test.rb#L30

This prompts a MiniTest warning: 
```
DEPRECATED: Use assert_nil if expecting nil from test/models/facebook_post_test.rb:30. This will fail in Minitest 6.
```

This PR changes the comparison. 

## Testing instructions
`rake`