### PR TITLE
Improve the must_be_logged_out redirection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,8 +19,7 @@ protected
     unless current_user.nil?
       respond_to do |format|
         format.html do
-          flash[:error] = "You cannot access that resource while logged in. Please log out and try again."
-          redirect_to after_sign_in_path_for(current_user)
+          redirect_back_or_to after_sign_in_path_for(current_user), allow_other_host: false, flash: { error: "You cannot access that resource while logged in. Please log out and try again." }
         end
         format.turbo_stream do
           flash.now[:error] = "You cannot access that resource while logged in. Please log out and try again."


### PR DESCRIPTION
I wasn’t aware of `redirect_back_or_to` when I wrote my convoluted `ApplicationController#must_be_logged_out` method, despite it being used literally in that same file. Fun!

This quick fix makes use of it. It is caught by a test (`rails t test/controllers/accounts_controller_test`), so run that and make sure it's clean.

There's no accompanying issue, it's just a quick thing I noticed.