### PR TITLE
Fix authentication on all controller methods

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -83,7 +83,7 @@ protected
     authenticate_user!
 
     unless current_user.is_admin?
-      redirect_back_or_to "/", allow_other_host: false, alert: "You must be a super user/admin to access this page."
+      redirect_back_or_to "/", allow_other_host: false, alert: "You don’t have permission to access that page."
     end
   end
 end

--- a/app/controllers/archive_controller.rb
+++ b/app/controllers/archive_controller.rb
@@ -1,10 +1,9 @@
 # typed: strict
 
 class ArchiveController < ApplicationController
-  # It's the index, list all the archived items
-
   before_action :authenticate_user!, except: :scrape_result_callback
 
+  # It's the index, list all the archived items
   sig { void }
   def index
     respond_to do | format |

--- a/app/controllers/facebook_users_controller.rb
+++ b/app/controllers/facebook_users_controller.rb
@@ -1,4 +1,8 @@
+# typed: strict
+
 class FacebookUsersController < ApplicationController
+  before_action :authenticate_user!
+
   sig { void }
   def show
     @facebook_user = Sources::FacebookUser.find(params[:id])

--- a/app/controllers/image_search_controller.rb
+++ b/app/controllers/image_search_controller.rb
@@ -1,7 +1,8 @@
 # typed: strict
 
 class ImageSearchController < ApplicationController
-  # before_action :authenticate_user!
+  before_action :authenticate_user!
+
   # A class representing the allowed params into the `index` endpoint
   class IndexUrlParams < T::Struct
     const :q_id, T.nilable(String)

--- a/app/controllers/instagram_users_controller.rb
+++ b/app/controllers/instagram_users_controller.rb
@@ -1,5 +1,8 @@
-"typed: strict"
+# typed: strict
+
 class InstagramUsersController < ApplicationController
+  before_action :authenticate_user!
+
   sig { void }
   def show
     @instagram_user = Sources::InstagramUser.find(params[:id])

--- a/app/controllers/jobs_status_controller.rb
+++ b/app/controllers/jobs_status_controller.rb
@@ -3,6 +3,8 @@
 class JobsStatusController < ApplicationController
   require "sidekiq/api"
 
+  before_action :authenticate_super_user!
+
   RESULTS_PER_PAGE = 10
 
   # A class representing the allowed params into the `search` endpoint

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -1,7 +1,0 @@
-# typed: strict
-
-class LoginController < ApplicationController
-  sig { void }
-  def index
-  end
-end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class SettingsController < ApplicationController
-  require "sidekiq/api"
-end

--- a/app/controllers/twitter_users_controller.rb
+++ b/app/controllers/twitter_users_controller.rb
@@ -1,6 +1,8 @@
 # typed: strict
 
 class TwitterUsersController < ApplicationController
+  before_action :authenticate_user!
+
   sig { void }
   def show
     @twitter_user = Sources::TwitterUser.find(params[:id])

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,22 +4,19 @@ class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
-  def new
-    @title_tag = "Log in"
-    super
-  end
+  # def new
+  #   super
+  # end
 
   # POST /resource/sign_in
-  def create
-    self.resource = warden.authenticate!(auth_options)
-    set_flash_message!(:notice, :signed_in)
-    sign_in(resource_name, resource)
-    yield resource if block_given?
-    respond_with resource, location: after_sign_in_path_for(resource)
-    # super
-  end
+  # def create
+  #   super
+  # end
 
   # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
 
   # protected
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  before_action :must_be_logged_out, only: [:new]
+
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in

--- a/app/controllers/youtube_channels_controller.rb
+++ b/app/controllers/youtube_channels_controller.rb
@@ -1,4 +1,8 @@
+# typed: strict
+
 class YoutubeChannelsController < ApplicationController
+  before_action :authenticate_user!
+
   sig { void }
   def show
     @youtube_channel = Sources::YoutubeChannel.find(params[:id])

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,3 +1,5 @@
+<% @title_tag = "Log in" %>
+
 <div class="box box--sm box--miniform">
 	<p>
 		To access Zenodotus, please log in below.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,27 +3,16 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
-  # These routes come along automatically from Devise, but we don't want them to (for now).
-  # Thus, we redirect them to the root. Must be declared before the `devise_for` block below.
-  get "users/cancel", to: redirect("/")
-  get "users/sign_up", to: redirect("/")
-  get "users/edit", to: redirect("/")
-
-  # This generates only the session and registration-related Devise URLs. We actually only want the
-  # session URLs for the userspace, but the registration-related routes are necessary for tests to
-  # run properly. (The ones that we override above also come from this. If we can somehow exclude
-  # them in this configuration block, that would be amazing.)
+  # This generates only the session and confirmation-related Devise URLs.
   devise_for :users,
              skip: :all,
              only: [
-              :sessions,
-              :registrations,
-              :confirmations
+               :sessions,
+               :confirmations,
              ],
              controllers: {
                sessions: "users/sessions",
-               registrations: "users/registrations",
-               confirmations: "users/confirmations"
+               confirmations: "users/confirmations",
              }
 
   root "archive#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,8 @@ Rails.application.routes.draw do
   root "archive#index"
 
   scope "/apply" do
-    get "/", to: "applicants#new", as: :new_applicant
-    resources :applicants, path: "/", only: [:create]
+    get "/", to: "applicants#new", as: "new_applicant"
+    post "/", to: "applicants#create", as: "applicants"
     get "/confirm", to: "applicants#confirm", as: "applicant_confirm"
     get "/confirm/sent", to: "applicants#confirmation_sent", as: "applicant_confirmation_sent"
     get "/confirm/done", to: "applicants#confirmed", as: "applicant_confirmed"

--- a/test/controllers/applicants_controller_test.rb
+++ b/test/controllers/applicants_controller_test.rb
@@ -1,7 +1,63 @@
 require "test_helper"
 
 class ApplicantsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  include Devise::Test::IntegrationHelpers
+
+  test "can access the apply page while logged out" do
+    get new_applicant_path
+    assert_response :success
+  end
+
+  test "cannot access the apply page while logged in" do
+    user = users(:user)
+
+    sign_in user
+
+    get new_applicant_path
+    assert_response :redirect
+  end
+
+  test "creates an applicant" do
+    post applicants_path(applicant: {
+      name: "Jane Doe",
+      email: "applicant@example.com",
+      use_case: "Journalism?",
+      accepted_terms: "1",
+    })
+
+    assert Applicant.find_by(email: "applicant@example.com")
+    assert_redirected_to applicant_confirmation_sent_path
+  end
+
+  test "redirects to confirmation sent page after creation" do
+    post applicants_path(applicant: {
+      name: "Jane Doe",
+      email: "applicant@example.com",
+      use_case: "Journalism?",
+      accepted_terms: "1",
+    })
+
+    assert_redirected_to applicant_confirmation_sent_path
+  end
+
+  test "returns a bad request if validations fails during creation" do
+    post applicants_path(applicant: {
+      name: "Jane Doe",
+    })
+
+    assert_response :bad_request
+  end
+
+  test "returns a bad request if user exists for applicant's email" do
+    user = users(:user)
+
+    post applicants_path(applicant: {
+      name: "Jane Doe",
+      email: user.email,
+      use_case: "Journalism?",
+      accepted_terms: "1",
+    })
+
+    assert_response :bad_request
+  end
 end

--- a/test/controllers/facebook_users_controller_test.rb
+++ b/test/controllers/facebook_users_controller_test.rb
@@ -1,0 +1,25 @@
+# typed: ignore
+
+require "test_helper"
+
+class FacebookUsersControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test "cannot view Facebook user if logged out" do
+    facebook_user = sources_facebook_users(:facebook_user)
+
+    get facebook_user_path(id: facebook_user.id)
+
+    assert_response :redirect
+  end
+
+  test "can view Facebook user if logged in" do
+    facebook_user = sources_facebook_users(:facebook_user)
+
+    sign_in users(:user)
+
+    get facebook_user_path(id: facebook_user.id)
+
+    assert_response :success
+  end
+end

--- a/test/controllers/image_search_controller_test.rb
+++ b/test/controllers/image_search_controller_test.rb
@@ -3,7 +3,36 @@
 require "test_helper"
 
 class ImageSearchControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
+  include Devise::Test::IntegrationHelpers
+
+  test "must be logged in to view image search" do
+    get image_search_url
+    assert_response :redirect
+  end
+
+  test "may view image search if logged in" do
+    sign_in users(:user)
+
+    get image_search_url
+    assert_response :success
+  end
+
+  # This test is currently meaningless since it redirects even when search worked.
+  # test "must be logged in to perform image search" do
+  #   post image_search_submit_url
+  #   assert_response :redirect
+  # end
+
+  # This test is currently unimplemented since I'm unsure how to mock an
+  # `ActionDispatch::Http::UploadedFile` parameter, and also (as above) it will redirect.
+  # test "may perfrom image search if logged in" do
+  #   sign_in users(:user)
+
+  #   image_file = "something"
+
+  #   post image_search_submit_url(image_search: {
+  #     image: image_file
+  #   })
+  #   assert_response :success
   # end
 end

--- a/test/controllers/instagram_users_controller_test.rb
+++ b/test/controllers/instagram_users_controller_test.rb
@@ -1,7 +1,25 @@
+# typed: ignore
+
 require "test_helper"
 
 class InstagramUsersControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  include Devise::Test::IntegrationHelpers
+
+  test "cannot view Instagram user if logged out" do
+    instagram_user = sources_instagram_users(:instagram_user)
+
+    get instagram_user_path(id: instagram_user.id)
+
+    assert_response :redirect
+  end
+
+  test "can view Instagram user if logged in" do
+    instagram_user = sources_instagram_users(:instagram_user)
+
+    sign_in users(:user)
+
+    get instagram_user_path(id: instagram_user.id)
+
+    assert_response :success
+  end
 end

--- a/test/controllers/jobs_status_controller_test.rb
+++ b/test/controllers/jobs_status_controller_test.rb
@@ -1,17 +1,25 @@
 require "test_helper"
 
-class JobsTrackerControllerTest < ActionDispatch::IntegrationTest
+class JobsStatusControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   test "can view jobs" do
-    sign_in users(:user)
-    InstagramMediaSource.extract("https://www.instagram.com/p/CBcqOkyDDH8/", false)
+    sign_in users(:admin)
+
     get jobs_status_index_path
     assert_response :success
   end
 
-  test "can resubmit a scrape" do
+  test "cannot view jobs as a non-admin user" do
     sign_in users(:user)
+
+    get jobs_status_index_path
+    assert_response :redirect
+    assert_equal "You don’t have permission to access that page.", flash[:alert]
+  end
+
+  test "can resubmit a scrape" do
+    sign_in users(:admin)
     scrape = Scrape.create({ fulfilled: false, url: "https://www.instagram.com/p/CBcqOkyDDH8/", scrape_type: :instagram })
     assert_not_nil scrape
 
@@ -25,7 +33,7 @@ class JobsTrackerControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "can delete a scrape" do
-    sign_in users(:user)
+    sign_in users(:admin)
     scrape = Scrape.create({ fulfilled: false, url: "https://www.instagram.com/p/CBcqOkyDDH8/", scrape_type: :instagram })
     assert_not_nil scrape
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test "can load the login page while logged out" do
+    get new_user_session_path
+    assert_response :success
+  end
+
+  test "cannot access the login page while logged in" do
+    user = users(:user)
+
+    sign_in user
+
+    get new_user_session_path
+    assert_response :redirect
+  end
+end

--- a/test/controllers/text_search_controller_test.rb
+++ b/test/controllers/text_search_controller_test.rb
@@ -5,6 +5,30 @@ require "test_helper"
 class ArchiveControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
+  test "must be logged in to view text search" do
+    get text_search_url
+    assert_response :redirect
+  end
+
+  test "may view text search if logged in" do
+    sign_in users(:user)
+
+    get text_search_url
+    assert_response :success
+  end
+
+  test "must be logged in to perform text search" do
+    get text_search_submit_url query: "Biden"
+    assert_response :redirect
+  end
+
+  test "may perform text search if logged in" do
+    sign_in users(:user)
+
+    get text_search_submit_url query: "Biden"
+    assert_response :success
+  end
+
   test "can run text search" do
     # First we need to create a few posts.
     Sources::Tweet.create_from_url("https://twitter.com/POTUS/status/1430341234472669188")

--- a/test/controllers/twitter_users_controller_test.rb
+++ b/test/controllers/twitter_users_controller_test.rb
@@ -3,7 +3,23 @@
 require "test_helper"
 
 class TwitterUsersControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  include Devise::Test::IntegrationHelpers
+
+  test "cannot view Twitter user if logged out" do
+    twitter_user = sources_twitter_users(:twitter_user)
+
+    get twitter_user_path(id: twitter_user.id)
+
+    assert_response :redirect
+  end
+
+  test "can view Twitter user if logged in" do
+    twitter_user = sources_twitter_users(:twitter_user)
+
+    sign_in users(:user)
+
+    get twitter_user_path(id: twitter_user.id)
+
+    assert_response :success
+  end
 end

--- a/test/controllers/youtube_channels_controller_test.rb
+++ b/test/controllers/youtube_channels_controller_test.rb
@@ -1,0 +1,25 @@
+# typed: ignore
+
+require "test_helper"
+
+class YoutubeChannelsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test "cannot view YouTube channel if logged out" do
+    youtube_channel = sources_youtube_channels(:youtube_channel)
+
+    get youtube_channel_path(id: youtube_channel.id)
+
+    assert_response :redirect
+  end
+
+  test "can view YouTube channel if logged in" do
+    youtube_channel = sources_youtube_channels(:youtube_channel)
+
+    sign_in users(:user)
+
+    get youtube_channel_path(id: youtube_channel.id)
+
+    assert_response :success
+  end
+end

--- a/test/fixtures/sources/facebook_users.yml
+++ b/test/fixtures/sources/facebook_users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+facebook_user:
+  facebook_id: 1234
+  name: "Facebook User"
+  profile: "Description of the user."
+  url: "http://www.example.com"
+  profile_image_url: "http://www.example.com/image.jpg"
+  followers_count: 10
+  likes_count: 20
+  verified: true

--- a/test/fixtures/sources/instagram_users.yml
+++ b/test/fixtures/sources/instagram_users.yml
@@ -1,0 +1,12 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+instagram_user:
+  handle: example
+  display_name: "Instagram User"
+  profile: "Description of the user."
+  url: "http://www.example.com"
+  profile_image_url: "http://www.example.com/image.jpg"
+  followers_count: 10
+  following_count: 20
+  number_of_posts: 30
+  verified: true

--- a/test/fixtures/sources/twitter_users.yml
+++ b/test/fixtures/sources/twitter_users.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+twitter_user:
+  twitter_id: 1234
+  handle: example
+  display_name: "Twitter User"
+  description: "Description of the user."
+  location: "Dallas, TX"
+  url: "http://www.example.com"
+  profile_image_url: "http://www.example.com/image.jpg"
+  sign_up_date: <%= Time.now %>
+  followers_count: 10
+  following_count: 20

--- a/test/fixtures/sources/youtube_channels.yml
+++ b/test/fixtures/sources/youtube_channels.yml
@@ -1,0 +1,12 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+youtube_channel:
+  youtube_id: 1234
+  title: "YouTube Channel"
+  description: "Description of the channel."
+  sign_up_date: <%= Time.now %>
+  num_videos: 10
+  num_subscribers: 20
+  num_views: 30
+  made_for_kids: true
+  channel_image_data: {}

--- a/test/fixtures/twitter_users.yml
+++ b/test/fixtures/twitter_users.yml
@@ -1,7 +1,0 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# one:
-#   handle: MyString
-
-# two:
-#   handle: MyString


### PR DESCRIPTION
This PR locks down all routes that need locking down, ensures the ones that need to be open are open, and adds tests to catch as much of this as possible.

I opened #166 after noticing that I could hit pages I wasn't supposed to be able to, such as a Twitter user page while logged out, or a Jobs status page while logged in as a user (not admin). Now, all pages should be locked down correctly.

It looks like a huge PR, but a ton of it are just new tests. That said, a lot of controllers were touched (and unused ones removed), so feel free to comb through.

⚠️ Note that the commits are organized sensibly, so it might be preferable to go through each commit individually since the description may provide relevant change context.

**Testing:**
- `rails t` obviously
- I highly recommend doing a full login, poke around, archive URL, etc. as multiple types of users. Notify me of anything newly weird.

Closes #166