### PR TITLE
Use the non-`ActiveJob` flow when the "add to archive" button is clicked

### DIFF
--- a/app/controllers/archive_controller.rb
+++ b/app/controllers/archive_controller.rb
@@ -36,7 +36,7 @@ class ArchiveController < ApplicationController
     url = typed_params.url_to_archive
     object_model = ArchiveItem.model_for_url(url)
     begin
-      object_model.create_from_url(url, current_user)
+      object_model.create_from_url!(url, current_user)
     rescue StandardError => e
       respond_to do |format|
         error = "#{e.class}: #{e.message}"


### PR DESCRIPTION
Our manual archive button currently executes the `ActiveJob` flow, which expects that:
1. An orphaned `MediaReview` item will be created
2. We'll scrape Hypatia and create an `ArchiveItem`
3. We'll attach the orphaned `MediaReview` to the newly created `ArchiveItem`

But step 1 only happens if we either manually create a `MediaReview` item or receive one from FactStream (which happens in production).

Since no one but the dev team uses the "add to archive button", we can change it to skip the `ActiveJob` MediaReview fulfillment flow and just create an `ArchiveItem`.

Closes https://github.com/TechAndCheck/zenodotus/issues/360