### PR TITLE
Lowercase applicant emails for better matching against users

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -28,8 +28,11 @@ class ApplicantsController < ApplicationController
       generic_create_error && return
     end
 
-    params_with_token = applicant_params.merge(confirmation_token: Devise.friendly_token)
-    @applicant = Applicant.new(params_with_token)
+    decorated_params = applicant_params.merge({
+      # Add the confirmation token the applicant uses to confirm their email address
+      confirmation_token: Devise.friendly_token,
+    })
+    @applicant = Applicant.new(decorated_params)
 
     existing_user = User.readonly.find_by(email: @applicant[:email].downcase)
     # We intentionally return a generic error to avoid leaking the existence of the user.

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -31,7 +31,7 @@ class ApplicantsController < ApplicationController
     params_with_token = applicant_params.merge(confirmation_token: Devise.friendly_token)
     @applicant = Applicant.new(params_with_token)
 
-    existing_user = User.readonly.find_by(email: @applicant[:email])
+    existing_user = User.readonly.find_by(email: @applicant[:email].downcase)
     # We intentionally return a generic error to avoid leaking the existence of the user.
     (generic_create_error && return) if existing_user
 

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -21,6 +21,7 @@ class Applicant < ApplicationRecord
 
   after_initialize :map_terms_database_values_to_accessor
   before_create :map_terms_accessor_to_database_values
+  before_save :downcase_email!
 
   # Records the time that the we were able to successful confirm the applicant's email address.
   #
@@ -113,6 +114,11 @@ class Applicant < ApplicationRecord
   end
 
 private
+
+  sig { void }
+  def downcase_email!
+    self.email.downcase! if self.email
+  end
 
   # The `accepted_terms` attribute should reflect the current status of the database (or itself,
   # if already set).

--- a/test/controllers/applicants_controller_test.rb
+++ b/test/controllers/applicants_controller_test.rb
@@ -73,4 +73,22 @@ class ApplicantsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :bad_request
   end
+
+  test "should lowercase email address during creation" do
+    email_upcase = "APPLICANT@EXAMPLE.COM"
+    email_downcase = email_upcase.downcase
+
+    post applicants_path(applicant: {
+      name: "Jane Doe",
+      email: email_upcase,
+      use_case: "Journalism?",
+      accepted_terms: "1",
+    })
+
+    assert_nil Applicant.find_by(email: email_upcase)
+
+    applicant = Applicant.find_by(email: email_downcase)
+
+    assert_equal email_downcase, applicant.email
+  end
 end

--- a/test/controllers/applicants_controller_test.rb
+++ b/test/controllers/applicants_controller_test.rb
@@ -48,12 +48,25 @@ class ApplicantsControllerTest < ActionDispatch::IntegrationTest
     assert_response :bad_request
   end
 
-  test "returns a bad request if user exists for applicant's email" do
+  test "should not allow applying with existing user email" do
     user = users(:user)
 
     post applicants_path(applicant: {
       name: "Jane Doe",
       email: user.email,
+      use_case: "Journalism?",
+      accepted_terms: "1",
+    })
+
+    assert_response :bad_request
+  end
+
+  test "should not allow applying with existing user email in different case" do
+    user = users(:user)
+
+    post applicants_path(applicant: {
+      name: "Jane Doe",
+      email: user.email.upcase,
       use_case: "Journalism?",
       accepted_terms: "1",
     })

--- a/test/models/applicant_test.rb
+++ b/test/models/applicant_test.rb
@@ -24,6 +24,19 @@ class ApplicantTest < ActiveSupport::TestCase
     assert_not @applicant.valid?
   end
 
+  test "should lowercase email address during creation" do
+    applicant = Applicant.create!({
+      name: "Jane Doe",
+      email: "JANE@EXAMPLE.COM",
+      use_case: "Use case",
+      accepted_terms_at: Time.now,
+      accepted_terms_version: TermsOfService::CURRENT_VERSION,
+      confirmation_token: Devise.friendly_token,
+    })
+
+    assert_equal applicant.email.downcase, applicant.email
+  end
+
   test "cannot create an applicant without accepting terms" do
     assert_raises ActiveRecord::RecordInvalid do
       Applicant.create!({


### PR DESCRIPTION
_This PR ladders off #359._

This PR closes a loophole that would let people apply using an existing users' email address by changing the casing. (Of course, they'd not have been able to close the loop on becoming a user since they'd hit our uniqueness restrictions during the user-creation process, but this stops them a lot earlier.)

Note that it does the downcasing in two places:

1. As part of a `before_save` action on the model itself; this keeps it out of the database entirely. I could have done this via `after_initialize` so that `Applicant.new` would have it, but I wanted that to represent the user's input until the actual save point.
2. As part of the check for existing users in the controller action. Here I could have changed the casing while passing the params to `Applicant.new`, but that violated the controller-model responsibility split IMO (and would have meant this was the _only_ place the email was downcased).

**Testing:**
- On `master`, apply for an account using `ADMIN@example.com` (or some other cased-differently email currently in your **Users** table)
- ❌ The application should be allowed through. Bad!
- Switch to this branch and repeat the exercise.
- ✅ You should get booted back to the application page with a vague error about being unable to complete. (The language here predates this PR and is intentionally vague so as not to confirm the existence of an account.)

Closes #356