### PR TITLE
Simplify author JSON export

### DIFF
--- a/app/controllers/archive_controller.rb
+++ b/app/controllers/archive_controller.rb
@@ -67,8 +67,9 @@ class ArchiveController < ApplicationController
   # Export entire archive of reviewed media to a JSON File
   sig { void }
   def export_archive_data
-    archive_json = ArchiveItem.prune_archive_items
-    send_data archive_json, type: "application/json; header=present", disposition: "attachment; filename=archive.json"
+    send_data ArchiveItem.generate_pruned_json,
+      type: "application/json",
+      filename: "media_vault_archive.json"
   end
 
   # A class representing the allowed params into the `submit_url` endpoint

--- a/app/controllers/facebook_users_controller.rb
+++ b/app/controllers/facebook_users_controller.rb
@@ -9,19 +9,14 @@ class FacebookUsersController < ApplicationController
     facebook_post_archive_items = ArchiveItem.includes(archivable_item: [:author, :images, :videos])
                                              .where(archivable_item_type: "Sources::FacebookPost")
     facebook_posts_by_user = facebook_post_archive_items.select { |t| t.facebook_post.author == @facebook_user }
-    @archive_items = facebook_posts_by_user
-  end
 
-  # Exports all media items created by the currently viewed Facebook user to a JSON file
-  sig { void }
-  def export_facebook_user_data
-    facebook_post_archive_items = ArchiveItem.includes(archivable_item: [:author])
-                                             .where(archivable_item_type: "Sources::FacebookPost")
-    facebook_user = Sources::FacebookUser.find(params[:id])
-    facebook_posts_by_user = facebook_post_archive_items.select { |t| t.facebook_post.author == facebook_user }
-    facebook_post_archive_json = ArchiveItem.prune_archive_items(facebook_posts_by_user)
-    send_data facebook_post_archive_json,
-              type: "application/json; header=present",
-              disposition: "attachment; filename=#{facebook_user.name.parameterize(separator: '_')}_facebook_archive.json"
+    respond_to do |format|
+      format.html { @archive_items = facebook_posts_by_user }
+      format.json do
+        send_data ArchiveItem.generate_pruned_json(facebook_posts_by_user),
+          type: "application/json",
+          filename: "#{@facebook_user.name.parameterize(separator: '_')}_facebook_archive.json"
+      end
+    end
   end
 end

--- a/app/controllers/instagram_users_controller.rb
+++ b/app/controllers/instagram_users_controller.rb
@@ -9,19 +9,14 @@ class InstagramUsersController < ApplicationController
     instagram_post_archive_items = ArchiveItem.includes(archivable_item: [:author, :images, :videos])
                                               .where(archivable_item_type: "Sources::InstagramPost")
     instagram_posts_by_user = instagram_post_archive_items.select { |t| t.instagram_post.author == @instagram_user }
-    @archive_items = instagram_posts_by_user
-  end
 
-  # Exports all media items created by the currently viewed Instagram user to a JSON file
-  sig { void }
-  def export_instagram_user_data
-    instagram_post_archive_items = ArchiveItem.includes(archivable_item: [:author])
-                                     .where(archivable_item_type: "Sources::InstagramPost")
-    instagram_user = Sources::InstagramUser.find(params[:id])
-    instagram_posts_by_user = instagram_post_archive_items.select { |t| t.instagram_post.author == instagram_user }
-    instagram_post_archive_json = ArchiveItem.prune_archive_items(instagram_posts_by_user)
-    send_data instagram_post_archive_json,
-              type: "application/json; header=present",
-              disposition: "attachment; filename=#{instagram_user.display_name.parameterize(separator: '_')}_instagram_archive.json"
+    respond_to do |format|
+      format.html { @archive_items = instagram_posts_by_user }
+      format.json do
+        send_data ArchiveItem.generate_pruned_json(instagram_posts_by_user),
+          type: "application/json",
+          filename: "#{@instagram_user.display_name.parameterize(separator: '_')}_instagram_archive.json"
+      end
+    end
   end
 end

--- a/app/controllers/twitter_users_controller.rb
+++ b/app/controllers/twitter_users_controller.rb
@@ -9,19 +9,14 @@ class TwitterUsersController < ApplicationController
     tweet_archive_items = ArchiveItem.includes(archivable_item: [:author, :images, :videos])
                                      .where(archivable_item_type: "Sources::Tweet")
     tweets_by_author = tweet_archive_items.select { |t| t.tweet.author == @twitter_user }
-    @archive_items = tweets_by_author
-  end
 
-  # Exports all media items created by the currently viewed Twitter user to a JSON file
-  sig { void }
-  def export_tweeter_data
-    tweet_archive_items = ArchiveItem.includes(archivable_item: [:author])
-                                     .where(archivable_item_type: "Sources::Tweet")
-    twitter_user = Sources::TwitterUser.find(params[:id])
-    tweets_by_author = tweet_archive_items.select { |t| t.tweet.author == twitter_user }
-    tweet_archive_json = ArchiveItem.prune_archive_items(tweets_by_author)
-    send_data tweet_archive_json,
-              type: "application/json; header=present",
-              disposition: "attachment; filename=#{twitter_user.display_name.parameterize(separator: '_')}_twitter_archive.json"
+    respond_to do |format|
+      format.html { @archive_items = tweets_by_author }
+      format.json do
+        send_data ArchiveItem.generate_pruned_json(tweets_by_author),
+          type: "application/json",
+          filename: "#{@twitter_user.display_name.parameterize(separator: '_')}_twitter_archive.json"
+      end
+    end
   end
 end

--- a/app/controllers/youtube_channels_controller.rb
+++ b/app/controllers/youtube_channels_controller.rb
@@ -9,19 +9,14 @@ class YoutubeChannelsController < ApplicationController
     youtube_post_archive_items = ArchiveItem.includes(archivable_item: [:author, :images, :videos])
                                             .where(archivable_item_type: "Sources::YoutubePost")
     youtube_posts_by_channel = youtube_post_archive_items.select { |t| t.youtube_post.author == @youtube_channel }
-    @archive_items = youtube_posts_by_channel
-  end
 
-  # Exports all media items created by the currently viewed YouTube channel to a JSON file
-  sig { void }
-  def export_youtube_channel_data
-    youtube_post_archive_items = ArchiveItem.includes(archivable_item: [:author])
-                                            .where(archivable_item_type: "Sources::YoutubePost")
-    youtube_channel = Sources::YoutubeChannel.find(params[:id])
-    youtube_posts_by_channel = youtube_post_archive_items.select { |t| t.youtube_post.author == youtube_channel }
-    youtube_post_archive_json = ArchiveItem.prune_archive_items(youtube_posts_by_channel)
-    send_data youtube_post_archive_json,
-              type: "application/json; header=present",
-              disposition: "attachment; filename=#{youtube_channel.title.parameterize(separator: '_')}_youtube_archive.json"
+    respond_to do |format|
+      format.html { @archive_items = youtube_posts_by_channel }
+      format.json do
+        send_data ArchiveItem.generate_pruned_json(youtube_posts_by_channel),
+          type: "application/json",
+          filename: "#{@youtube_channel.title.parameterize(separator: '_')}_youtube_archive.json"
+      end
+    end
   end
 end

--- a/app/models/archive_item.rb
+++ b/app/models/archive_item.rb
@@ -46,7 +46,7 @@ class ArchiveItem < ApplicationRecord
   # @params relation T.Array[ArchiveItem] a set of ArchiveItems to be exported
   # @return a stringified representation of ArchiveItems for export
   sig { params(relation: T.nilable(T::Array[ArchiveItem])).returns(String) }
-  def self.prune_archive_items(relation = nil)
+  def self.generate_pruned_json(relation = nil)
     relation ||= ArchiveItem.includes(:media_review, archivable_item: [:author])
     relation.to_json(only: [:id, :created_at],
                      include: [ { media_review: { except: [:id, :created_at, :updated_at, :archive_item_id] } },

--- a/app/views/facebook_users/show.html.erb
+++ b/app/views/facebook_users/show.html.erb
@@ -30,7 +30,7 @@
       archived
     </h2>
     <div class="author-archive__actions">
-      <%= link_to facebook_user_download_path, {
+      <%= link_to facebook_user_path(@facebook_user, format: "json"), {
         title: "Download user archive in JSON format",
         class: "btn icon-prefixed",
         download: true

--- a/app/views/instagram_users/show.html.erb
+++ b/app/views/instagram_users/show.html.erb
@@ -31,7 +31,7 @@
       archived
     </h2>
     <div class="author-archive__actions">
-      <%= link_to instagram_user_download_path, {
+      <%= link_to instagram_user_path(@instagram_user, format: "json"), {
         title: "Download user archive in JSON format",
         class: "btn icon-prefixed",
         download: true

--- a/app/views/twitter_users/show.html.erb
+++ b/app/views/twitter_users/show.html.erb
@@ -46,7 +46,7 @@
       archived
     </h2>
     <div class="author-archive__actions">
-      <%= link_to twitter_user_download_path, {
+      <%= link_to twitter_user_path(@twitter_user, format: "json"), {
         title: "Download user archive in JSON format",
         class: "btn icon-prefixed",
         download: true

--- a/app/views/youtube_channels/show.html.erb
+++ b/app/views/youtube_channels/show.html.erb
@@ -46,7 +46,7 @@
       archived
     </h2>
     <div class="author-archive__actions">
-      <%= link_to youtube_channel_download_path, {
+      <%= link_to youtube_channel_path(@youtube_channel, format: "json"), {
         title: "Download channel archive in JSON format",
         class: "btn icon-prefixed",
         download: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,9 +56,4 @@ Rails.application.routes.draw do
   resources :instagram_users, only: [:show]
   resources :facebook_users, only: [:show]
   resources :youtube_channels, only: [:show]
-
-  get "/facebook_users/:id/download", to: "facebook_users#export_facebook_user_data", as: "facebook_user_download"
-  get "/instagram_users/:id/download", to: "instagram_users#export_instagram_user_data", as: "instagram_user_download"
-  get "/twitter_users/:id/download", to: "twitter_users#export_tweeter_data", as: "twitter_user_download"
-  get "/youtube_channels/:id/download", to: "youtube_channels#export_youtube_channel_data", as: "youtube_channel_download"
 end

--- a/test/controllers/facebook_users_controller_test.rb
+++ b/test/controllers/facebook_users_controller_test.rb
@@ -8,7 +8,7 @@ class FacebookUsersControllerTest < ActionDispatch::IntegrationTest
   test "cannot view Facebook user if logged out" do
     facebook_user = sources_facebook_users(:facebook_user)
 
-    get facebook_user_path(id: facebook_user.id)
+    get facebook_user_path(facebook_user)
 
     assert_response :redirect
   end
@@ -18,7 +18,7 @@ class FacebookUsersControllerTest < ActionDispatch::IntegrationTest
 
     sign_in users(:user)
 
-    get facebook_user_path(id: facebook_user.id)
+    get facebook_user_path(facebook_user)
 
     assert_response :success
   end

--- a/test/controllers/facebook_users_controller_test.rb
+++ b/test/controllers/facebook_users_controller_test.rb
@@ -22,4 +22,20 @@ class FacebookUsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test "can download user archive in JSON format" do
+    facebook_user = sources_facebook_users(:facebook_user)
+
+    sign_in users(:user)
+
+    get facebook_user_path(facebook_user, format: "json")
+
+    assert_response :success
+
+    begin
+      assert JSON.parse(@response.body)
+    rescue JSON::ParserError
+      flunk "Valid JSON was not returned."
+    end
+  end
 end

--- a/test/controllers/instagram_users_controller_test.rb
+++ b/test/controllers/instagram_users_controller_test.rb
@@ -22,4 +22,20 @@ class InstagramUsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test "can download user archive in JSON format" do
+    instagram_user = sources_instagram_users(:instagram_user)
+
+    sign_in users(:user)
+
+    get instagram_user_path(instagram_user, format: "json")
+
+    assert_response :success
+
+    begin
+      assert JSON.parse(@response.body)
+    rescue JSON::ParserError
+      flunk "Valid JSON was not returned."
+    end
+  end
 end

--- a/test/controllers/instagram_users_controller_test.rb
+++ b/test/controllers/instagram_users_controller_test.rb
@@ -8,7 +8,7 @@ class InstagramUsersControllerTest < ActionDispatch::IntegrationTest
   test "cannot view Instagram user if logged out" do
     instagram_user = sources_instagram_users(:instagram_user)
 
-    get instagram_user_path(id: instagram_user.id)
+    get instagram_user_path(instagram_user)
 
     assert_response :redirect
   end
@@ -18,7 +18,7 @@ class InstagramUsersControllerTest < ActionDispatch::IntegrationTest
 
     sign_in users(:user)
 
-    get instagram_user_path(id: instagram_user.id)
+    get instagram_user_path(instagram_user)
 
     assert_response :success
   end

--- a/test/controllers/twitter_users_controller_test.rb
+++ b/test/controllers/twitter_users_controller_test.rb
@@ -22,4 +22,20 @@ class TwitterUsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test "can download user archive in JSON format" do
+    twitter_user = sources_twitter_users(:twitter_user)
+
+    sign_in users(:user)
+
+    get twitter_user_path(twitter_user, format: "json")
+
+    assert_response :success
+
+    begin
+      assert JSON.parse(@response.body)
+    rescue JSON::ParserError
+      flunk "Valid JSON was not returned."
+    end
+  end
 end

--- a/test/controllers/twitter_users_controller_test.rb
+++ b/test/controllers/twitter_users_controller_test.rb
@@ -8,7 +8,7 @@ class TwitterUsersControllerTest < ActionDispatch::IntegrationTest
   test "cannot view Twitter user if logged out" do
     twitter_user = sources_twitter_users(:twitter_user)
 
-    get twitter_user_path(id: twitter_user.id)
+    get twitter_user_path(twitter_user)
 
     assert_response :redirect
   end
@@ -18,7 +18,7 @@ class TwitterUsersControllerTest < ActionDispatch::IntegrationTest
 
     sign_in users(:user)
 
-    get twitter_user_path(id: twitter_user.id)
+    get twitter_user_path(twitter_user)
 
     assert_response :success
   end

--- a/test/controllers/youtube_channels_controller_test.rb
+++ b/test/controllers/youtube_channels_controller_test.rb
@@ -22,4 +22,20 @@ class YoutubeChannelsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test "can download channel archive in JSON format" do
+    youtube_channel = sources_youtube_channels(:youtube_channel)
+
+    sign_in users(:user)
+
+    get youtube_channel_path(youtube_channel, format: "json")
+
+    assert_response :success
+
+    begin
+      assert JSON.parse(@response.body)
+    rescue JSON::ParserError
+      flunk "Valid JSON was not returned."
+    end
+  end
 end

--- a/test/controllers/youtube_channels_controller_test.rb
+++ b/test/controllers/youtube_channels_controller_test.rb
@@ -8,7 +8,7 @@ class YoutubeChannelsControllerTest < ActionDispatch::IntegrationTest
   test "cannot view YouTube channel if logged out" do
     youtube_channel = sources_youtube_channels(:youtube_channel)
 
-    get youtube_channel_path(id: youtube_channel.id)
+    get youtube_channel_path(youtube_channel)
 
     assert_response :redirect
   end
@@ -18,7 +18,7 @@ class YoutubeChannelsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in users(:user)
 
-    get youtube_channel_path(id: youtube_channel.id)
+    get youtube_channel_path(youtube_channel)
 
     assert_response :success
   end


### PR DESCRIPTION
This PR cleans up how we're generating the JSON export file for our authors. Previously, it was a separate route from the `show` action with its own nearly-identical-but-not-quite query.

Now, it's all within `show` and performs the same query, but customizes the generation based on format requested (HTML v. JSON). It also removes the now-unused routes and adds tests of the JSON generation.

This came out of looking at #235, which was already fixed, but this makes it even more fixed. Fixeder.

**Testing:**
- You may have to `bundle install` depending on previous setup
- `rails t` of course
- Run the app and go to the author pages for each type (Twitter, Instagram, Facebook, and YouTube)
- ✅ Make sure the JSON download button… downloads JSON!

Closes #235 