### PR TITLE
Fix MediaVault routes to remove `media_vault` path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
     get "/confirm/done", to: "applicants#confirmed", as: "applicant_confirmed"
   end
 
-  namespace "media_vault" do
+  scope module: "media_vault", as: "media_vault" do
     scope "archive", as: "archive" do
       get "add", to: "archive#add"
       post "add", to: "archive#submit_url"


### PR DESCRIPTION
b7df27d3d8fb1f54f8a7b2f4e06241da81ba6dd8 intentionally namespaced the MV-related routes under `media_vault`, but this was meant to prefix the helpers (`media_vault_foo_bar_url`) and the controllers (`MediaVault::FooController`). It was _not_ intended to insert `media_vault/` into each path, which the `namespace` approach does.

This PR fixes that by using `scope` instead.

**Testing:**
- `rails t` (of course)
- Start the app, log in, and click "Text Search". The URL should just be `{hostname}/text_search`. If it is `{hostname}/media_vault/text_search`, then things are still screwy.

Issue #301