### PR TITLE
Serve Vault and Insights on discrete domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,14 @@ A faster image manipulation library than ImageMagick.
    1. For local development, `touch config/application.yml` and ask another developer for the config values
    1. For production, make sure the environment variables are set properly
 1. For local development, bootstrap the assets: `rails assets:precompile`
+1. Add the following entries to your `/etc/hosts` file:
+   ```
+   127.0.0.1	www.factcheckinsights.local
+   127.0.0.1	vault.factcheckinsights.local
+   ```
 1. In your shell, run `rails s` (to fire up just the Puma server) or `./bin/dev` (to also fire up the JS/CSS bundler, if you'll be modifying those assets)
 
-✨ The app should now be running and available at [http://localhost:3000](http://localhost:3000). If not, contact @cguess or another developer.
+✨ The app should now be running and available at [http://www.factcheckinsights.local:3000](http://www.factcheckinsights.local:3000) (Insights) and [http://vault.factcheckinsights.local:3000](http://vault.factcheckinsights.local:3000) (MediaVault). If not, contact @cguess or another developer.
 
 #### Starting the scraper
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :null_session, if: :json_request?, prepend: true
 
+  before_action :set_site_from_subdomain
+
   sig { void }
   def index
     (render("media_vault/index") && return) if site_is_media_vault?
@@ -44,6 +46,18 @@ protected
     # segments[1] == "factcheckinsights" && segments[2] == "www"
     # However, for now, since we want to always fall back to Insights, we'll just do this:
     !site_is_media_vault?
+  end
+
+  sig { void }
+  def set_site_from_subdomain
+    if site_is_media_vault?
+      @site = "media_vault"
+      @site_title = "MediaVault"
+      return
+    end
+
+    @site = "fact_check_insights"
+    @site_title = "Fact-Check Insights"
   end
 
   sig { returns(T::Boolean) }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,17 +9,42 @@ class ApplicationController < ActionController::Base
 
   sig { void }
   def index
-    # TODO: Split this based on subdomain.
-    render "media_vault/index"
+    (render("media_vault/index") && return) if site_is_media_vault?
+
+    render "fact_check_insights/index"
   end
 
   sig { params(user: User).returns(String) }
   def after_sign_in_path_for(user)
-    # TODO: Split this based on subdomain.
-    media_vault_archive_root_path
+    return media_vault_archive_root_path if site_is_media_vault?
+
+    root_path
   end
 
 protected
+
+  # Given a domain hostname, returns an array with each segment in reverse order: TLD first, then
+  # primary domain, then subdomains. E.g., `"www.example.com"` → `["com","example","www"]`.
+  # Explicitly expects to operate on only the hostname, not the protocol, ports, path, etc.
+  sig { params(hostname: String).returns(Array) }
+  def hostname_segments(hostname)
+    hostname.split(".").reverse
+  end
+
+  sig { returns(T::Boolean) }
+  def site_is_media_vault?
+    segments = hostname_segments(request.host)
+    segments[1] == "factcheckinsights" && segments[2] == "vault"
+  end
+
+  sig { returns(T::Boolean) }
+  def site_is_fact_check_insights?
+    # The real way to determine this is:
+    # segments = hostname_segments(request.host)
+    # segments[1] == "factcheckinsights" && segments[2] == "www"
+    # However, for now, since we want to always fall back to Insights, we'll just do this:
+    !site_is_media_vault?
+  end
 
   sig { returns(T::Boolean) }
   def json_request?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,18 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :null_session, if: :json_request?, prepend: true
 
+  sig { void }
+  def index
+    # TODO: Split this based on subdomain.
+    render "media_vault/index"
+  end
+
+  sig { params(user: User).returns(String) }
+  def after_sign_in_path_for(user)
+    # TODO: Split this based on subdomain.
+    media_vault_archive_root_path
+  end
+
 protected
 
   sig { returns(T::Boolean) }
@@ -60,13 +72,6 @@ protected
       return false
     end
     true
-  end
-
-  # Routes users to the sign in page after they've logged out
-  # Overrides the Devise default method, which re-routes users to the root page
-  sig { params(user: Symbol).returns(String) }
-  def after_sign_out_path_for(user)
-    new_user_session_path
   end
 
   sig { returns(T::Boolean) }

--- a/app/controllers/fact_check_insights_controller.rb
+++ b/app/controllers/fact_check_insights_controller.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class FactCheckInsightsController < ApplicationController
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,7 +14,7 @@ module ApplicationHelper
       title_tag_content += title_hierarchy.join(" #{opts[:delimeter]} ")
     end
 
-    (title_tag_content.present? ? "#{title_tag_content} #{opts[:delimeter]} " : "") + "Zenodotus"
+    (title_tag_content.present? ? "#{title_tag_content} #{opts[:delimeter]} " : "") + @site_title
   end
 
   def color_for_flash_type(flash_type)

--- a/app/helpers/fact_check_insights_helper.rb
+++ b/app/helpers/fact_check_insights_helper.rb
@@ -1,0 +1,2 @@
+module FactCheckInsightsHelper
+end

--- a/app/views/fact_check_insights/index.html.erb
+++ b/app/views/fact_check_insights/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Welcome to Fact-Check Insights</h1>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -43,7 +43,7 @@
     <div id="zeno--mobile-menu" class="hidden justify-between items-center z-50 absolute top-full left-0 px-4 shadow bg-white w-full md:relative md:flex md:w-auto md:h-auto md:shadow-none md:bg-none md:px-0 md:left-auto md:top-auto md:order-1">
       <ul class="flex flex-nowrap flex-col py-4 md:py-0 md:flex-row md:gap-x-8 md:text-sm md:font-medium md:items-center">
         <% if user_signed_in? %>
-          <li><%= link_to "Browse the Vault", root_path, "data-turbo-frame": "_top", class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
+          <li><%= link_to "Browse the Vault", media_vault_archive_root_path, "data-turbo-frame": "_top", class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
           <li class="hidden">
             <div class="relative flex flex-inline items-center">
               <div class="flex absolute inset-y-0 left-0 items-center pl-3 pointer-events-none">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,14 +16,14 @@
 
   <body class="bg-gray-50 text-gray-800">
     <div class="flex flex-col min-h-screen">
-      <%= render "layouts/header" %>
+      <%= render "layouts/#{@site}/header" %>
       <div class="grow flex relative shadow z-1">
         <div class="container mx-auto max-w-screen-xl px-2 sm:px-4">
           <%= render "layouts/flashes/turbo_flashes" %>
           <%= yield %>
         </div>
       </div>
-      <%= render "layouts/footer" %>
+      <%= render "layouts/#{@site}/footer" %>
     </div>
     <%= render "layouts/svg_library" %>
   </body>

--- a/app/views/layouts/fact_check_insights/_footer.html.erb
+++ b/app/views/layouts/fact_check_insights/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="p-6 bg-gray-700 text-gray-200 text-sm">
     <div class="container mx-auto">
         <div class="text-center">
-            <%= link_to 'Zenodotus', root_path %>
+            <%= link_to 'Fact-Check Insights', root_path %>
             is a project of
             <%= link_to 'Tech & Check', 'https://reporterslab.org/tech-and-check/', class: "whitespace-nowrap"  %>
             at the

--- a/app/views/layouts/fact_check_insights/_header.html.erb
+++ b/app/views/layouts/fact_check_insights/_header.html.erb
@@ -2,7 +2,7 @@
   <div class="flex flex-nowrap justify-between items-center gap-x-8">
     <%= link_to root_path, class: 'flex items-center p-2 gap-x-2 text-xl font-semibold whitespace-nowrap dark:text-white no-underline mr-auto hover:text-blue-700' do %>
 			<svg class="h-8 w-8"><use xlink:href="#svg-library"></use></svg>
-      <span>Zenodotus</span>
+      <span>Fact-Check Insights</span>
     <% end %>
     <div class="flex flex-nowrap items-center md:order-2">
       <% if user_signed_in? %>
@@ -43,32 +43,7 @@
     <div id="zeno--mobile-menu" class="hidden justify-between items-center z-50 absolute top-full left-0 px-4 shadow bg-white w-full md:relative md:flex md:w-auto md:h-auto md:shadow-none md:bg-none md:px-0 md:left-auto md:top-auto md:order-1">
       <ul class="flex flex-nowrap flex-col py-4 md:py-0 md:flex-row md:gap-x-8 md:text-sm md:font-medium md:items-center">
         <% if user_signed_in? %>
-          <li><%= link_to "Browse the Vault", media_vault_archive_root_path, "data-turbo-frame": "_top", class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
-          <li class="hidden">
-            <div class="relative flex flex-inline items-center">
-              <div class="flex absolute inset-y-0 left-0 items-center pl-3 pointer-events-none">
-                <svg class="w-5 h-5 text-gray-500" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"></path></svg>
-              </div>
-              <input type="text" id="search-navbar" placeholder="Search…" class="block p-2 pl-10 w-full text-gray-900 bg-gray-50 rounded-lg border border-gray-300 sm:text-sm focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
-            </div>
-            <div class="flex hidden">
-              <button title="Search by text" type="button" class="inline-flex items-center px-3 text-sm text-gray-100 hover:text-gray-900 bg-gray-800 hover:bg-gray-300 border border-r-0 border-gray-300 rounded-l-md dark:bg-gray-600 dark:text-gray-400 dark:border-gray-600">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h7" /></svg>
-              </button>
-              <button title="Search by image or video" type="button" class="inline-flex items-center px-3 text-sm text-gray-900 bg-gray-200 hover:bg-gray-400 border border-r-0 border-gray-300 dark:bg-gray-600 dark:text-gray-400 dark:border-gray-600">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd" /></svg>
-              </button>
-              <input type="text" class="rounded-none rounded-r-lg bg-gray-50 border border-gray-300 text-gray-900 focus:ring-blue-500 focus:border-blue-500 block flex-1 min-w-0 w-full text-sm border-gray-300 p-2.5  dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="Search…">
-            </div>
-          </li>
-          <li><%= link_to "Text Search", media_vault_text_search_path, "data-turbo-frame": "_top", class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
-          <li><%= link_to "Media Search", media_vault_image_search_path, "data-turbo-frame": "_top", class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
-          <li>
-            <%= link_to media_vault_archive_add_path, "data-turbo-frame": "modal", class: "flex flex-inline items-center gap-1 no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" do %>
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-              Archive URL
-            <% end %>
-          </li>
+					<li>(Insights Pages TBD)</li>
         <% else %>
           <li><%= link_to "Request access", new_applicant_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
           <li><%= link_to "Log in", new_user_session_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>

--- a/app/views/layouts/media_vault/_footer.html.erb
+++ b/app/views/layouts/media_vault/_footer.html.erb
@@ -1,0 +1,19 @@
+<footer class="p-6 bg-gray-700 text-gray-200 text-sm">
+    <div class="container mx-auto">
+        <div class="text-center">
+            <%= link_to 'MediaVault', root_path %>
+            is a project of
+            <%= link_to 'Tech & Check', 'https://reporterslab.org/tech-and-check/', class: "whitespace-nowrap"  %>
+            at the
+            <%= link_to 'Duke Reporters’ Lab', 'https://reporterslab.org/', class: "whitespace-nowrap" %>.
+        </div>
+        <ul class="flex flex-wrap justify-center items-center mt-2 gap-x-6">
+            <li class="translate-y-0.5">
+                <%= link_to 'https://github.com/TechAndCheck/zenodotus/', class: "gap-2 inline-flex items-center whitespace-nowrap" do %>
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" /></svg>
+                    Contribute via GitHub
+                <% end %>
+            </li>
+        </ul>
+    </div>
+</footer>

--- a/app/views/layouts/media_vault/_header.html.erb
+++ b/app/views/layouts/media_vault/_header.html.erb
@@ -1,0 +1,79 @@
+<nav class="bg-white shadow relative z-10 px-2 sm:px-4 py-2.5 dark:bg-gray-800">
+  <div class="flex flex-nowrap justify-between items-center gap-x-8">
+    <%= link_to root_path, class: 'flex items-center p-2 gap-x-2 text-xl font-semibold whitespace-nowrap dark:text-white no-underline mr-auto hover:text-blue-700' do %>
+			<svg class="h-8 w-8"><use xlink:href="#svg-library"></use></svg>
+      <span>MediaVault</span>
+    <% end %>
+    <div class="flex flex-nowrap items-center md:order-2">
+      <% if user_signed_in? %>
+        <button data-dropdown-toggle="zeno--user-menu" type="button" class="flex text-sm rounded-full focus:ring-4 focus:ring-gray-300 dark:focus:ring-gray-600" id="zeno--user-menu-button" aria-expanded="false" type="button">
+          <span class="sr-only">Open user menu</span>
+          <svg class="w-10 h-10 rounded-full" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-6-3a2 2 0 11-4 0 2 2 0 014 0zm-2 4a5 5 0 00-4.546 2.916A5.986 5.986 0 0010 16a5.986 5.986 0 004.546-2.084A5 5 0 0010 11z" clip-rule="evenodd" /></svg>
+        </button>
+        <div id="zeno--user-menu" class="hidden z-50 my-4 text-base list-none bg-white rounded divide-y divide-gray-100 shadow dark:bg-gray-700 dark:divide-gray-600">
+          <div class="py-3 px-4">
+            <span class="block text-sm font-medium text-gray-500 truncate dark:text-gray-400"><%= current_user.email %></span>
+          </div>
+          <ul class="py-1" aria-labelledby="dropdown">
+            <li>
+              <%= link_to "Settings", account_path, class: "block no-underline py-2 px-4 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 dark:text-gray-200 dark:hover:text-white" %>
+            </li>
+            <% if current_user.is_admin? %>
+              <li>
+                <%= link_to jobs_status_index_path, class: "flex flex-inline gap-1 block no-underline py-2 px-4 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 dark:text-gray-200 dark:hover:text-white" do %>
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd" /></svg>
+                  Jobs Status
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+          <ul class="py-1">
+            <li>
+              <%= button_to "Logout", destroy_user_session_path, method: :delete, class: "block w-full text-left no-underline py-2 px-4 text-sm text-red-800 hover:bg-gray-100 dark:hover:bg-gray-600 dark:text-gray-200 dark:hover:text-white" %>
+            </li>
+          </ul>
+        </div>
+      <% end %>
+      <button data-collapse-toggle="zeno--mobile-menu" type="button" class="inline-flex items-center p-2 ml-1 text-sm text-gray-500 rounded-lg md:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600" aria-controls="mobile-menu-2" aria-expanded="false">
+        <span class="sr-only">Open main menu</span>
+        <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"></path></svg>
+        <svg class="hidden w-6 h-6" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
+      </button>
+    </div>
+    <div id="zeno--mobile-menu" class="hidden justify-between items-center z-50 absolute top-full left-0 px-4 shadow bg-white w-full md:relative md:flex md:w-auto md:h-auto md:shadow-none md:bg-none md:px-0 md:left-auto md:top-auto md:order-1">
+      <ul class="flex flex-nowrap flex-col py-4 md:py-0 md:flex-row md:gap-x-8 md:text-sm md:font-medium md:items-center">
+        <% if user_signed_in? %>
+          <li><%= link_to "Browse the Vault", media_vault_archive_root_path, "data-turbo-frame": "_top", class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
+          <li class="hidden">
+            <div class="relative flex flex-inline items-center">
+              <div class="flex absolute inset-y-0 left-0 items-center pl-3 pointer-events-none">
+                <svg class="w-5 h-5 text-gray-500" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"></path></svg>
+              </div>
+              <input type="text" id="search-navbar" placeholder="Search…" class="block p-2 pl-10 w-full text-gray-900 bg-gray-50 rounded-lg border border-gray-300 sm:text-sm focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+            </div>
+            <div class="flex hidden">
+              <button title="Search by text" type="button" class="inline-flex items-center px-3 text-sm text-gray-100 hover:text-gray-900 bg-gray-800 hover:bg-gray-300 border border-r-0 border-gray-300 rounded-l-md dark:bg-gray-600 dark:text-gray-400 dark:border-gray-600">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h7" /></svg>
+              </button>
+              <button title="Search by image or video" type="button" class="inline-flex items-center px-3 text-sm text-gray-900 bg-gray-200 hover:bg-gray-400 border border-r-0 border-gray-300 dark:bg-gray-600 dark:text-gray-400 dark:border-gray-600">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd" /></svg>
+              </button>
+              <input type="text" class="rounded-none rounded-r-lg bg-gray-50 border border-gray-300 text-gray-900 focus:ring-blue-500 focus:border-blue-500 block flex-1 min-w-0 w-full text-sm border-gray-300 p-2.5  dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="Search…">
+            </div>
+          </li>
+          <li><%= link_to "Text Search", media_vault_text_search_path, "data-turbo-frame": "_top", class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
+          <li><%= link_to "Media Search", media_vault_image_search_path, "data-turbo-frame": "_top", class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
+          <li>
+            <%= link_to media_vault_archive_add_path, "data-turbo-frame": "modal", class: "flex flex-inline items-center gap-1 no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+              Archive URL
+            <% end %>
+          </li>
+        <% else %>
+          <li><%= link_to "Request access", new_applicant_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
+          <li><%= link_to "Log in", new_user_session_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/app/views/media_vault/index.html.erb
+++ b/app/views/media_vault/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Welcome to MediaVault.</h1>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module Zenodotus
     config.active_job.queue_adapter = :sidekiq
 
     # This lets Action Mailer generate URLs using the helper methods
+    # TODO: This should be dynamic in the mailer based on the request subdomain.
     config.action_mailer.default_url_options = { host: Figaro.env.URL }
 
     config.action_mailer.delivery_method = :mailgun

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,5 +70,7 @@ Rails.application.configure do
   # Prefix job queues names to avoid collisions
   config.active_job.queue_name_prefix = "zenodotus_development"
 
+  config.hosts << "www.factcheckinsights.local"
+  config.hosts << "vault.factcheckinsights.local"
   config.hosts << "showoff-reporterslab.pagekite.me"
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :cookie_store, key: "_fact_check_insights_session", domain: :all, tld_length: 2

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,30 +25,32 @@ Rails.application.routes.draw do
     get "/confirm/done", to: "applicants#confirmed", as: "applicant_confirmed"
   end
 
-  scope module: "media_vault", as: "media_vault" do
-    scope "archive", as: "archive" do
-      root "archive#index"
-      get "add", to: "archive#add"
-      post "add", to: "archive#submit_url"
-      get "download", to: "archive#export_archive_data", as: "download"
-      post "scrape_result_callback", to: "archive#scrape_result_callback", as: "scrape_result_callback"
+  constraints subdomain: "vault" do
+    scope module: "media_vault", as: "media_vault" do
+      scope "archive", as: "archive" do
+        root "archive#index"
+        get "add", to: "archive#add"
+        post "add", to: "archive#submit_url"
+        get "download", to: "archive#export_archive_data", as: "download"
+        post "scrape_result_callback", to: "archive#scrape_result_callback", as: "scrape_result_callback"
+      end
+
+      scope "ingest", as: "ingest" do
+        post "submit_media_review", to: "ingest#submit_media_review", as: "api_raw"
+        post "submit_media_review_source", to: "ingest#submit_media_review_source", as: "api_url"
+      end
+
+      get "/image_search", to: "image_search#index", as: "image_search"
+      post "/image_search", to: "image_search#search", as: "image_search_submit"
+
+      get "/text_search", to: "text_search#index", as: "text_search"
+      get "/text_search/search", to: "text_search#search", as: "text_search_submit"
+
+      resources :twitter_users, only: [:show]
+      resources :instagram_users, only: [:show]
+      resources :facebook_users, only: [:show]
+      resources :youtube_channels, only: [:show]
     end
-
-    scope "ingest", as: "ingest" do
-      post "submit_media_review", to: "ingest#submit_media_review", as: "api_raw"
-      post "submit_media_review_source", to: "ingest#submit_media_review_source", as: "api_url"
-    end
-
-    get "/image_search", to: "image_search#index", as: "image_search"
-    post "/image_search", to: "image_search#search", as: "image_search_submit"
-
-    get "/text_search", to: "text_search#index", as: "text_search"
-    get "/text_search/search", to: "text_search#search", as: "text_search_submit"
-
-    resources :twitter_users, only: [:show]
-    resources :instagram_users, only: [:show]
-    resources :facebook_users, only: [:show]
-    resources :youtube_channels, only: [:show]
   end
 
   get "/account", to: "accounts#index", as: "account"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
+  root "application#index"
+
   # This generates only the session and confirmation-related Devise URLs.
   devise_for :users,
              skip: :all,
@@ -15,8 +17,6 @@ Rails.application.routes.draw do
                confirmations: "users/confirmations",
              }
 
-  root "media_vault/archive#index"
-
   scope "/apply" do
     get "/", to: "applicants#new", as: "new_applicant"
     post "/", to: "applicants#create", as: "applicants"
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
 
   scope module: "media_vault", as: "media_vault" do
     scope "archive", as: "archive" do
+      root "archive#index"
       get "add", to: "archive#add"
       post "add", to: "archive#submit_url"
       get "download", to: "archive#export_archive_data", as: "download"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,6 +2,18 @@
 
 ## Environment Setup
 
+### Hosts
+
+This app serves two sites (Fact-Check Insights and MediaVault), each on their own subdomain. To dynamically serve the correct experience, you should no longer access the site via `http://localhost`, but via a locally-routed domains rooted at `factcheckinsights.local`.
+
+Add the following entries to your `/etc/hosts` file:
+```
+127.0.0.1	www.factcheckinsights.local
+127.0.0.1	vault.factcheckinsights.local
+```
+
+After starting the app, you will get to Insights via `http://www.factcheckinsights.local:3000` and to Vault via `http://vault.factcheckinsights.local:3000`. (If you setup your own local reverse proxy, you can do away with the `:3000` and/or setup HTTPS, as you wish.)
+
 ### Environment variables
 To run Zenodotus, you'll need to set the following environment variables. Ask a dev on the team to provide you access to them. 
 - `TWITTER_BEARER_TOKEN`

--- a/test/controllers/fact_check_insights_controller_test.rb
+++ b/test/controllers/fact_check_insights_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FactCheckInsightsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/media_vault/archive_controller_test.rb
+++ b/test/controllers/media_vault/archive_controller_test.rb
@@ -6,6 +6,10 @@ class MediaVault::ArchiveControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
   include Minitest::Hooks
 
+  setup do
+    host! "vault.factcheckinsights.local"
+  end
+
   def around
     AwsS3Downloader.stub(:download_file_in_s3_received_from_hypatia, S3_MOCK_STUB) do
       super

--- a/test/controllers/media_vault/archive_controller_test.rb
+++ b/test/controllers/media_vault/archive_controller_test.rb
@@ -19,13 +19,13 @@ class MediaVault::ArchiveControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "index redirects without authentication" do
-    get root_url
+    get media_vault_archive_root_url
     assert_redirected_to new_user_session_path
   end
 
   test "load index if authenticated" do
     sign_in users(:user)
-    get root_url
+    get media_vault_archive_root_url
     assert_response :success
   end
 

--- a/test/controllers/media_vault/facebook_users_controller_test.rb
+++ b/test/controllers/media_vault/facebook_users_controller_test.rb
@@ -5,6 +5,10 @@ require "test_helper"
 class MediaVault::FacebookUsersControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
+  setup do
+    host! "vault.factcheckinsights.local"
+  end
+
   test "cannot view Facebook user if logged out" do
     facebook_user = sources_facebook_users(:facebook_user)
 

--- a/test/controllers/media_vault/image_search_controller_test.rb
+++ b/test/controllers/media_vault/image_search_controller_test.rb
@@ -5,6 +5,10 @@ require "test_helper"
 class MediaVault::ImageSearchControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
+  setup do
+    host! "vault.factcheckinsights.local"
+  end
+
   test "must be logged in to view image search" do
     get media_vault_image_search_url
     assert_response :redirect

--- a/test/controllers/media_vault/ingest_controller_test.rb
+++ b/test/controllers/media_vault/ingest_controller_test.rb
@@ -3,6 +3,10 @@
 require "test_helper"
 
 class MediaVault::IngestControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "vault.factcheckinsights.local"
+  end
+
   test "Submitting an API request without a key will return 401 error" do
     post media_vault_ingest_api_raw_path, params: { media_review_json: { title: "Ahoy!" }.to_json }, as: :json
     assert_response 401

--- a/test/controllers/media_vault/instagram_users_controller_test.rb
+++ b/test/controllers/media_vault/instagram_users_controller_test.rb
@@ -5,6 +5,10 @@ require "test_helper"
 class MediaVault::InstagramUsersControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
+  setup do
+    host! "vault.factcheckinsights.local"
+  end
+
   test "cannot view Instagram user if logged out" do
     instagram_user = sources_instagram_users(:instagram_user)
 

--- a/test/controllers/media_vault/text_search_controller_test.rb
+++ b/test/controllers/media_vault/text_search_controller_test.rb
@@ -5,6 +5,10 @@ require "test_helper"
 class MediaVault::TextSearchControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
+  setup do
+    host! "vault.factcheckinsights.local"
+  end
+
   test "must be logged in to view text search" do
     get media_vault_text_search_url
     assert_response :redirect

--- a/test/controllers/media_vault/twitter_users_controller_test.rb
+++ b/test/controllers/media_vault/twitter_users_controller_test.rb
@@ -5,6 +5,10 @@ require "test_helper"
 class MediaVault::TwitterUsersControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
+  setup do
+    host! "vault.factcheckinsights.local"
+  end
+
   test "cannot view Twitter user if logged out" do
     twitter_user = sources_twitter_users(:twitter_user)
 

--- a/test/controllers/media_vault/youtube_channels_controller_test.rb
+++ b/test/controllers/media_vault/youtube_channels_controller_test.rb
@@ -5,6 +5,10 @@ require "test_helper"
 class MediaVault::YoutubeChannelsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
+  setup do
+    host! "vault.factcheckinsights.local"
+  end
+
   test "cannot view YouTube channel if logged out" do
     youtube_channel = sources_youtube_channels(:youtube_channel)
 


### PR DESCRIPTION
🚨 **This is a PR with big consequences!**

Prior to this PR, things were nice and easy, as the entire app was hosted at a single domain. Locally, you could just fire up `http://localhost:3000` and be merry. Given our desired architecture, though, we want the app to appear as "Fact-Check Insights" when accessed via `www.factcheckinsights.org` and as "MediaVault" when accessed via `vault.factcheckinsights.org`. (They're both rooted at the same domain for session-sharing ease.)

Starting with this PR, we split the entire experience based on which subdomain you're using. While we fall back to the Insights experience (so `localhost` technically still works), if you want to see the MediaVault stuff — which is currently most of the site — you'll need to change your local setup.

- **To run Zenodotus**, you'll have to point `www.factcheckinsights.local` and `vault.factcheckinsights.local` to your localhost. I use `/etc/hosts`. If you want to get fancier with a local nginx and reverse proxy or whatnot, feel free.
- **To scrape / run Hypatia**, you'll also have to modify `URL` on the Zeno side to match (`http://vault.factcheckinsights.local:3000`), and modify `ZENODOTUS_URL` on the Hypatia side to match (`http://vault.factcheckinsights.local`). ⚠️ We should almost certainly rename our `URL` env var in Zeno to something more explicit, such as `MEDIA_VAULT_URL`.

After you've done all this, then when you fire up the app, you'll get to it from either `www.factcheckinsights.local` or `vault.factcheckinsights.local`, depending on which site you want. Logging in to either will log you in to the other as well, as the session is shared. Also, the Vault routes (e.g., `/archive`) are inaccessible at the `www` subdomain, by design.

⚠️ If your browser forces HTTPS, you'll want to make an exception for these domains.

**Testing:**
1. Do the prereq setup mentioned above to point the domains.
2. `rails t` of course
3. `rails s` and poke around the app at both domains, noting especially:
   - The domain-specific header and footer
   - The shared session between domains
   - The inaccessible Vault paths when on the Insights domain
4. Archive a URL to make sure scraping still works.

**Still to come:**
- The mailer uses the `URL` env var to construct URLs, which is currently pinned to Vault. This means all applications will get URLs that are rooted at `vault.factcheckinsights.local`. That will change so the mailer URLs are context-specific.
- Currently, all applicants look the same, but I will actually be storing which subdomain the applicant came from so the admin knows what site they're requesting access _to_. (Admins will be able to approve Vault access for any applicant even if they came from Insights, but this will be important context.)
- Actual content pages; right now the Insights nav is empty (aside from user stuff) and the Vault one is incomplete.

Issue #301