### PR TITLE
Create stubs for all pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,12 @@ class ApplicationController < ActionController::Base
     render "#{@site[:shortname]}/index"
   end
 
+  sig { void }
+  def about; end
+
+  sig { void }
+  def contact; end
+
   sig { params(user: User).returns(String) }
   def after_sign_in_path_for(user)
     if site_is_media_vault?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
   sig { params(user: User).returns(String) }
   def after_sign_in_path_for(user)
     if site_is_media_vault?
-      return media_vault_archive_root_path if user.can_access_media_vault?
+      return media_vault_dashboard_path if user.can_access_media_vault?
 
       # TODO: Lead to the Media Vault "Request Acces For Existing Insights User" page (#382)
       return media_vault_root_path

--- a/app/controllers/fact_check_insights_controller.rb
+++ b/app/controllers/fact_check_insights_controller.rb
@@ -1,4 +1,17 @@
 # typed: strict
 
 class FactCheckInsightsController < ApplicationController
+  # We don't route to this URL directly.
+  # Instead, `application#index` renders its template without a redirect.
+  sig { void }
+  def index; end
+
+  sig { void }
+  def download; end
+
+  sig { void }
+  def guide; end
+
+  sig { void }
+  def highlights; end
 end

--- a/app/controllers/media_vault_controller.rb
+++ b/app/controllers/media_vault_controller.rb
@@ -4,6 +4,14 @@ class MediaVaultController < ApplicationController
   before_action :authenticate_user!
   before_action :must_be_media_vault_user
 
+  # We don't route to this URL directly.
+  # Instead, `application#index` renders its template without a redirect.
+  sig { void }
+  def index; end
+
+  sig { void }
+  def guide; end
+
 protected
 
   sig { void }

--- a/app/views/applicants/confirmation_error.html.erb
+++ b/app/views/applicants/confirmation_error.html.erb
@@ -5,5 +5,5 @@
 		<svg class="icon icon--lg" style="color:var(--color--mood--error);"><use xlink:href="#svg-x-circle-outline"></use></svg>
 		<span>Email could not be confirmed.</span>
 	</h1>
-	<p>Sorry, we could not confirm your email address. Please try again, or contact us for more help.</p>
+	<p>Sorry, we could not confirm your email address. Please try again, or <%= link_to "contact us", contact_path %> for more help.</p>
 </div>

--- a/app/views/applicants/new.html.erb
+++ b/app/views/applicants/new.html.erb
@@ -11,7 +11,7 @@
 				Request access
 			</div>
 			<div class="fieldset__description">
-				<p>Access to the site requires approval by the Duke Reporters’ Lab team. Approval is usually determined within about one week. The more detail you can provide about who you are and how you want to use the data, the better. If you have any questions, please get in touch.</p>
+				<p>Access to the site requires approval by the Duke Reporters’ Lab team. Approval is usually determined within about one week. The more detail you can provide about who you are and how you want to use the data, the better. If you have any questions, please <%= link_to "contact us", contact_path %>.</p>
 			</div>
 		</div>
 		<div class="fieldset__fields">

--- a/app/views/application/about.html.erb
+++ b/app/views/application/about.html.erb
@@ -1,0 +1,3 @@
+<% @title_tag = "About Us" %>
+
+About Us

--- a/app/views/application/contact.html.erb
+++ b/app/views/application/contact.html.erb
@@ -1,0 +1,3 @@
+<% @title_tag = "Contact" %>
+
+Contact

--- a/app/views/fact_check_insights/download.html.erb
+++ b/app/views/fact_check_insights/download.html.erb
@@ -1,0 +1,3 @@
+<% @title_tag = "Download the Data" %>
+
+Download the Data

--- a/app/views/fact_check_insights/guide.html.erb
+++ b/app/views/fact_check_insights/guide.html.erb
@@ -1,0 +1,3 @@
+<% @title_tag = "Guide to the Data" %>
+
+Guide to the Data

--- a/app/views/fact_check_insights/highlights.html.erb
+++ b/app/views/fact_check_insights/highlights.html.erb
@@ -1,0 +1,3 @@
+<% @title_tag = "Highlights" %>
+
+Highlights

--- a/app/views/layouts/fact_check_insights/_header.html.erb
+++ b/app/views/layouts/fact_check_insights/_header.html.erb
@@ -47,9 +47,12 @@
     </div>
     <div id="zeno--mobile-menu" class="hidden justify-between items-center z-50 absolute top-full left-0 px-4 shadow bg-white w-full md:relative md:flex md:w-auto md:h-auto md:shadow-none md:bg-none md:px-0 md:left-auto md:top-auto md:order-1">
       <ul class="flex flex-nowrap flex-col py-4 md:py-0 md:flex-row md:gap-x-8 md:text-sm md:font-medium md:items-center">
-        <% if user_signed_in? %>
-					<li>(Insights Pages TBD)</li>
-        <% else %>
+          <li><%= link_to "Download the Data", fact_check_insights_download_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
+          <li><%= link_to "Guide to the Data", fact_check_insights_guide_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
+          <li><%= link_to "Highlights", fact_check_insights_highlights_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
+          <li><%= link_to "About Us", about_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
+          <li><%= link_to "Contact", contact_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
+				<% unless user_signed_in? %>
           <li><%= link_to "Request access", new_applicant_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
           <li><%= link_to "Log in", new_user_session_path, class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
         <% end %>

--- a/app/views/layouts/media_vault/_header.html.erb
+++ b/app/views/layouts/media_vault/_header.html.erb
@@ -47,7 +47,8 @@
       <ul class="flex flex-nowrap flex-col py-4 md:py-0 md:flex-row md:gap-x-8 md:text-sm md:font-medium md:items-center">
         <% if user_signed_in? %>
           <% if current_user.can_access_media_vault? %>
-            <li><%= link_to "Browse the Vault", media_vault_archive_root_path, "data-turbo-frame": "_top", class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
+            <li><%= link_to "Dashboard", media_vault_dashboard_path, "data-turbo-frame": "_top", class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
+            <li><%= link_to "Guide to MediaVault", media_vault_guide_path, "data-turbo-frame": "_top", class: "no-underline block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-gray-400 md:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent dark:border-gray-700" %></li>
             <li class="hidden">
               <div class="relative flex flex-inline items-center">
                 <div class="flex absolute inset-y-0 left-0 items-center pl-3 pointer-events-none">

--- a/app/views/media_vault/guide.html.erb
+++ b/app/views/media_vault/guide.html.erb
@@ -1,0 +1,3 @@
+<% @title_tag = "Guide to MediaVault" %>
+
+Guide

--- a/app/views/pages/credits.html.erb
+++ b/app/views/pages/credits.html.erb
@@ -1,1 +1,0 @@
-<div>Login icon made by <a href="" title="iconixar">iconixar</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a></div>

--- a/app/views/status/accounts/invalid_token.html.erb
+++ b/app/views/status/accounts/invalid_token.html.erb
@@ -5,5 +5,5 @@
 		<svg class="icon icon--lg" style="color:var(--color--mood--error);"><use xlink:href="#svg-x-circle-outline"></use></svg>
 		<span>Invalid token</span>
 	</h1>
-	<p>That token cannot be used to setup an account, either because it’s invalid or the account linked to it has already been setup. Please contact us if you need more help.</p>
+	<p>That token cannot be used to setup an account, either because it’s invalid or the account linked to it has already been setup. Please <%= link_to "contact us", contact_path %> if you need more help.</p>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,12 +17,25 @@ Rails.application.routes.draw do
                confirmations: "users/confirmations",
              }
 
+  get "about", to: "application#about"
+  get "contact", to: "application#contact"
+
   scope "/apply" do
     get "/", to: "applicants#new", as: "new_applicant"
     post "/", to: "applicants#create", as: "applicants"
     get "/confirm", to: "applicants#confirm", as: "applicant_confirm"
     get "/confirm/sent", to: "applicants#confirmation_sent", as: "applicant_confirmation_sent"
     get "/confirm/done", to: "applicants#confirmed", as: "applicant_confirmed"
+  end
+
+  constraints subdomain: "www" do
+    scope module: "fact_check_insights", as: "fact_check_insights" do
+      root "application#index"
+
+      get "download"
+      get "guide"
+      get "highlights"
+    end
   end
 
   constraints subdomain: "vault" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,8 +29,10 @@ Rails.application.routes.draw do
     scope module: "media_vault", as: "media_vault" do
       root "application#index"
 
+      get "dashboard", to: "archive#index"
+      get "guide"
+
       scope "archive", as: "archive" do
-        root "archive#index"
         get "add", to: "archive#add"
         post "add", to: "archive#submit_url"
         get "download", to: "archive#export_archive_data", as: "download"

--- a/test/controllers/media_vault/archive_controller_test.rb
+++ b/test/controllers/media_vault/archive_controller_test.rb
@@ -23,13 +23,13 @@ class MediaVault::ArchiveControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "index redirects without authentication" do
-    get media_vault_archive_root_url
+    get media_vault_dashboard_url
     assert_redirected_to new_user_session_path
   end
 
   test "load index if authenticated" do
     sign_in users(:user)
-    get media_vault_archive_root_url
+    get media_vault_dashboard_url
     assert_response :success
   end
 

--- a/test/controllers/media_vault_controller_test.rb
+++ b/test/controllers/media_vault_controller_test.rb
@@ -7,10 +7,10 @@ class MediaVaultControllerTest < ActionDispatch::IntegrationTest
     host! "vault.factcheckinsights.local"
   end
 
-  test "should not allow Insights-only users to view archive" do
+  test "should not allow Insights-only users to view dashboard" do
     sign_in users(:insights_user)
 
-    get media_vault_archive_root_url
+    get media_vault_dashboard_url
 
     assert_response :redirect
     assert_equal "You are not authorized to access that resource.", flash[:error]


### PR DESCRIPTION
This PR stubs out all the pages in our architecture, so that we can actually start adding content and design.

**Testing:**

- `rails s`
- Note that both Insights and Vault now have actual pages in the navigation!
- Make sure that the navigation follows the logged in / logged out behavior described [here](https://github.com/TechAndCheck/zenodotus/wiki/Information-Architecture).
  - Note that Vault's elements change more significantly that Insights does when logged in.
  - Ignore that MediaVault has two search links and an Archive URL that aren't in the architecture. TBD.
  - Ignore the drop-down menu design and "profile image v. username" thing. TBD.
  - Ignore styling, of course, including the separation of the page links and user links into separate elements.

Closes #377
Closes #335