### PR TITLE
Handle archive.org links

### DIFF
--- a/app/media_sources/facebook_media_source.rb
+++ b/app/media_sources/facebook_media_source.rb
@@ -21,7 +21,9 @@ class FacebookMediaSource < MediaSource
   # @returns [String or nil] the path of the screenshot if the screenshot was saved
   sig { override.params(url: String, force: T::Boolean).returns(T.any(T::Boolean,  T::Hash[String, String])) }
   def self.extract(url, force = false)
+    url = MediaSource.extract_post_url_if_needed(url)
     object = self.new(url)
+
     return object.retrieve_facebook_post! if force
 
     object.retrieve_facebook_post

--- a/app/media_sources/instagram_media_source.rb
+++ b/app/media_sources/instagram_media_source.rb
@@ -21,7 +21,9 @@ class InstagramMediaSource < MediaSource
   # @returns [Boolean or Hash] if `force` is set to `true` returns the scraped hash, otherwise the status of the Hypatia job.
   sig { override.params(url: String, force: T::Boolean).returns(T.any(T::Boolean, T::Hash[String, String])) }
   def self.extract(url, force = false)
+    url = MediaSource.extract_post_url_if_needed(url)
     object = self.new(url)
+
     return object.retrieve_instagram_post! if force
 
     object.retrieve_instagram_post

--- a/app/media_sources/media_source.rb
+++ b/app/media_sources/media_source.rb
@@ -25,6 +25,35 @@ class MediaSource
   sig { abstract.params(url: String).returns(T.untyped) }
   def self.extract(url); end
 
+  # Given a possibly ofuscated media post URL, return a URL pointing to the source of the post
+  # If the input URL already points to the source of the post, return the input URL
+  # Right now, this method just extracts post URLs from archive.org URLs, but we might add further layers of extraction in the future
+  #
+  # @!scope class
+  # @param url [String] the URL of a media post to be archived. May be obfuscated
+  # @return [String] A direct URL to the page/object to be archived
+  sig { params(url: String).returns(String) }
+  def self.extract_post_url_if_needed(url)
+    url = self.extract_post_url_from_archive_org_url(url)
+    url
+  end
+
+  # Extracts a MediaSource post URL from a potential archive.org URL
+  # If the input url turns out not to be an archive.org URL, returns the input URL untouched
+  #
+  # E.g. Given an input of https://web.archive.org/web/20190615000000*/https://www.foobar.com/post1
+  # This function will return https://www.foobar.com/post1
+  # Given an input of https://www.foobar.com/post1, it will return the input
+  #
+  # @!scope class
+  # @param url [String] the URL of a media post to be archived. May be an archive.org URL instead of a direct URL
+  # @return [String] A direct URL to the page/object to be archived
+  sig { params(url: String).returns(String) }
+  def self.extract_post_url_from_archive_org_url(url)
+    split_url = url.rpartition(/https?:\/\//) # partition string based on last occurence of "http(s)://" to get original url
+    split_url[1] + split_url[2] # return original URL scheme + rest of original URL
+  end
+
   # Check if +url+ has a host name the same as indicated by the +@@valid_host+ variable in a
   #   subclass.
   #

--- a/app/media_sources/twitter_media_source.rb
+++ b/app/media_sources/twitter_media_source.rb
@@ -31,8 +31,11 @@ class TwitterMediaSource < MediaSource
   # @returns [String or nil] the path of the screenshot if the screenshot was saved
   sig { override.params(url: String, force: T::Boolean).returns(T.any(T::Boolean, T::Hash[String, String])) }
   def self.extract(url, force = false)
+    url = MediaSource.extract_post_url_if_needed(url)
     object = self.new(url)
+
     return object.retrieve_tweet! if force
+
     object.retrieve_tweet
   end
 

--- a/app/media_sources/youtube_media_source.rb
+++ b/app/media_sources/youtube_media_source.rb
@@ -20,8 +20,11 @@ class YoutubeMediaSource < MediaSource
   # @returns Boolean
   sig { override.params(url: String, force: T::Boolean).returns(T.any(T::Boolean, T::Hash[String, String])) }
   def self.extract(url, force = false)
+    url = MediaSource.extract_post_url_if_needed(url)
     object = self.new(url)
+
     return object.retrieve_youtube_post! if force
+
     object.retrieve_youtube_post
   end
 

--- a/test/media_sources/media_source_test.rb
+++ b/test/media_sources/media_source_test.rb
@@ -35,4 +35,10 @@ class MediaSourceTest < ActiveSupport::TestCase
   test "Can archive media using archive.org URLs" do
     assert_not_nil Sources::Tweet.create_from_url!("https://web.archive.org/web/20220930151009/https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
   end
+
+  test "archive.org URL extraction does not affect normal URLs" do
+    tweet_url = "https://twitter.com/AmtrakNECAlerts/status/1397922363551870990"
+
+    assert_equal tweet_url, MediaSource.extract_post_url_if_needed(tweet_url)
+  end
 end

--- a/test/media_sources/media_source_test.rb
+++ b/test/media_sources/media_source_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class MediaSourceTest < ActiveSupport::TestCase
+  include Minitest::Hooks
+
+  def around
+    AwsS3Downloader.stub(:download_file_in_s3_received_from_hypatia, S3_MOCK_STUB) do
+      super
+    end
+  end
+
+  def after_all
+    if File.exist?("tmp") && File.directory?("tmp")
+      FileUtils.rm_r("tmp")
+    end
+  end
+
+  test "Can extract media post URLs from Archive.org addresses" do
+    # Check that we can archive URLs with different protocol schemes
+    https_post_url = "https://twitter.com/AmtrakNECAlerts/status/1397922363551870990"
+    http_post_url = "http://twitter.com/AmtrakNECAlerts/status/1397922363551870990"
+
+    archive_to_direct_url_map = {
+      "http://web.archive.org/web/20220930151009/https://twitter.com/AmtrakNECAlerts/status/1397922363551870990" => https_post_url,
+      "http://web.archive.org/web/20220930151009/http://twitter.com/AmtrakNECAlerts/status/1397922363551870990" => http_post_url,
+      "https://web.archive.org/web/20220930151009/http://twitter.com/AmtrakNECAlerts/status/1397922363551870990" => http_post_url,
+      "https://web.archive.org/web/20220930151009/https://twitter.com/AmtrakNECAlerts/status/1397922363551870990" => https_post_url
+    }
+
+    archive_to_direct_url_map.each  do |archive_url, post_url|
+      assert_equal post_url, MediaSource.extract_post_url_if_needed(archive_url)
+    end
+  end
+
+  test "Can archive media using archive.org URLs" do
+    assert_not_nil Sources::Tweet.create_from_url!("https://web.archive.org/web/20220930151009/https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
+  end
+end


### PR DESCRIPTION
This PR gives Zenodotus the ability to archive media re-hosted on archive.org 

If Zenodotus receives an Archive request for a media post hosted on archive.org, it will now try to extract the post's original URL and use it to generate a Hypatia scrape request. 

# Testing instructions
`rake`

Closes #380