### PR TITLE
Remove `MediaSource.runs_scraper_locally`

### DIFF
--- a/app/jobs/scraper_job.rb
+++ b/app/jobs/scraper_job.rb
@@ -15,11 +15,7 @@ class ScraperJob < ApplicationJob
 
   def perform(media_source_class, media_model, url, user)
     puts "Beginning to scrape #{url} @ #{Time.now}"
-    media_item = media_source_class.extract(url)
-
-    # If a scraper runs locally we can't create the actual model from the callback, so we do it now
-    media_model.create_from_hash(media_item, user) if media_source_class.runs_scraper_locally?
-
+    media_source_class.extract(url)
     puts "Done scraping #{url} @ #{Time.now}"
   end
 

--- a/app/media_sources/media_source.rb
+++ b/app/media_sources/media_source.rb
@@ -39,17 +39,6 @@ class MediaSource
     raise MediaSource::HostError.new(url, self)
   end
 
-  # This is a flag if the scraper is run by Hypatia or locally, mostly so the ScraperJob can know
-  # Default is false if not implemented
-  #
-  # @!scope class
-  # @return [Boolean] true if the scraper is run locally.
-  #   Raises an error if it's invalid.
-  sig { returns(T::Boolean) }
-  def self.runs_scraper_locally?
-    false
-  end
-
   # A error to indicate the host of a given url does not pass validation
   class HostError < StandardError
     extend T::Sig

--- a/app/media_sources/twitter_media_source.rb
+++ b/app/media_sources/twitter_media_source.rb
@@ -11,17 +11,6 @@ class TwitterMediaSource < MediaSource
     ["www.twitter.com", "twitter.com"]
   end
 
-  # This is a flag if the scraper is run by Hypatia or locally, mostly so the ScraperJob can know
-  # Default is false if not implemented
-  #
-  # @!scope class
-  # @return [Boolean] true if the scraper is run locally.
-  #   Raises an error if it's invalid.
-  sig { returns(T::Boolean) }
-  def self.runs_scraper_locally?
-    true
-  end
-
   # Capture a screenshot of the given url
   #
   # @!scope class


### PR DESCRIPTION
This PR removes the `runs_scraper_locally` method from our `MediaSource` class. 

With Birdsong migrated to Hypatia, Zenodotus no longer does any local scraping. 

Closes issue #386

# Testing instructions
`rake`
