### PR TITLE
Don’t send `callback_url` to Hypatia

### DIFF
--- a/app/media_sources/facebook_media_source.rb
+++ b/app/media_sources/facebook_media_source.rb
@@ -65,7 +65,6 @@ class FacebookMediaSource < MediaSource
     scrape = Scrape.create!({ url: @url, scrape_type: :facebook })
 
     params = { auth_key: Figaro.env.HYPATIA_AUTH_KEY, url: @url, callback_id: scrape.id }
-    params[:callback_url] = Figaro.env.MEDIA_VAULT_URL unless Figaro.env.MEDIA_VAULT_URL.blank?
 
     response = Typhoeus.get(
       Figaro.env.HYPATIA_SERVER_URL,
@@ -92,7 +91,6 @@ class FacebookMediaSource < MediaSource
     scrape = Scrape.create!({ url: @url, scrape_type: :instagram })
 
     params = { auth_key: Figaro.env.HYPATIA_AUTH_KEY, url: @url, callback_id: scrape.id, force: true }
-    params[:callback_url] = Figaro.env.MEDIA_VAULT_URL unless Figaro.env.MEDIA_VAULT_URL.blank?
 
     response = Typhoeus.get(
       Figaro.env.HYPATIA_SERVER_URL,

--- a/app/media_sources/instagram_media_source.rb
+++ b/app/media_sources/instagram_media_source.rb
@@ -52,7 +52,6 @@ class InstagramMediaSource < MediaSource
     scrape = Scrape.create!({ url: @url, scrape_type: :instagram })
 
     params = { auth_key: Figaro.env.HYPATIA_AUTH_KEY, url: @url, callback_id: scrape.id }
-    params[:callback_url] = Figaro.env.MEDIA_VAULT_URL unless Figaro.env.MEDIA_VAULT_URL.blank?
 
     response = Typhoeus.get(
       Figaro.env.HYPATIA_SERVER_URL,
@@ -80,7 +79,6 @@ class InstagramMediaSource < MediaSource
     scrape = Scrape.create!({ url: @url, scrape_type: :instagram })
 
     params = { auth_key: Figaro.env.HYPATIA_AUTH_KEY, url: @url, callback_id: scrape.id, force: true }
-    params[:callback_url] = Figaro.env.MEDIA_VAULT_URL unless Figaro.env.MEDIA_VAULT_URL.blank?
 
     response = Typhoeus.get(
       Figaro.env.HYPATIA_SERVER_URL,

--- a/app/media_sources/twitter_media_source.rb
+++ b/app/media_sources/twitter_media_source.rb
@@ -52,7 +52,6 @@ class TwitterMediaSource < MediaSource
     scrape = Scrape.create!({ url: @url, scrape_type: :twitter })
 
     params = { auth_key: Figaro.env.HYPATIA_AUTH_KEY, url: @url, callback_id: scrape.id }
-    params[:callback_url] = Figaro.env.MEDIA_VAULT_URL unless Figaro.env.MEDIA_VAULT_URL.blank?
 
     response = Typhoeus.get(
       Figaro.env.HYPATIA_SERVER_URL,
@@ -79,7 +78,6 @@ class TwitterMediaSource < MediaSource
     scrape = Scrape.create!({ url: @url, scrape_type: :twitter })
 
     params = { auth_key: Figaro.env.HYPATIA_AUTH_KEY, url: @url, callback_id: scrape.id, force: true }
-    params[:callback_url] = Figaro.env.MEDIA_VAULT_URL unless Figaro.env.MEDIA_VAULT_URL.blank?
 
     response = Typhoeus.get(
       Figaro.env.HYPATIA_SERVER_URL,

--- a/app/media_sources/youtube_media_source.rb
+++ b/app/media_sources/youtube_media_source.rb
@@ -62,7 +62,6 @@ class YoutubeMediaSource < MediaSource
     scrape = Scrape.create!({ url: @url, scrape_type: :youtube })
 
     params = { auth_key: Figaro.env.HYPATIA_AUTH_KEY, url: @url, callback_id: scrape.id }
-    params[:callback_url] = Figaro.env.MEDIA_VAULT_URL unless Figaro.env.MEDIA_VAULT_URL.blank?
 
     response = Typhoeus.get(
       Figaro.env.HYPATIA_SERVER_URL,
@@ -89,7 +88,6 @@ class YoutubeMediaSource < MediaSource
     scrape = Scrape.create!({ url: @url, scrape_type: :youtube })
 
     params = { auth_key: Figaro.env.HYPATIA_AUTH_KEY, url: @url, callback_id: scrape.id, force: true }
-    params[:callback_url] = Figaro.env.MEDIA_VAULT_URL unless Figaro.env.MEDIA_VAULT_URL.blank?
 
     response = Typhoeus.get(
       Figaro.env.HYPATIA_SERVER_URL,


### PR DESCRIPTION
This PR removes the ability to send a `callback_url` parameter to Hypatia. It's based on conversation with @cguess about how this functionality isn't needed. It means Hypatia will send all callbacks to whatever URL it is locally configured with, and individual requests can't override this.

**Testing:**
- `rails t`
- Test having Zeno send a scrape to Hypatia and be sure it succeeds

Closes #400