### PR TITLE
Configure apps with host names, not URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,15 +132,16 @@ An open-source JavaScript package manager used to install/manage JavaScript depe
 1. Set up your environment variables:
    1. For local development, `touch config/application.yml` and ask another developer for the config values
    1. For production, make sure the environment variables are set properly
-1. Add the following entries to your `/etc/hosts` file:
+1. Add the following entries to your `/etc/hosts` file (or equivalent, if you have a more complex routing setup):
    ```
    127.0.0.1	www.factcheckinsights.local
    127.0.0.1	vault.factcheckinsights.local
    ```
+   - These are just the suggested defaults. Feel free to replace this with an alternative routing method or different URLs.
 1. Bootstrap Tailwind: `rails tailwindcss:build`
 1. In your shell, run `rails s`
 
-✨ The app should now be running and available at [http://www.factcheckinsights.local:3000](http://www.factcheckinsights.local:3000) (Insights) and [http://vault.factcheckinsights.local:3000](http://vault.factcheckinsights.local:3000) (MediaVault). If not, contact @cguess or another developer.
+✨ The app should now be running and available at [http://www.factcheckinsights.local:3000](http://www.factcheckinsights.local:3000) (Insights) and [http://vault.factcheckinsights.local:3000](http://vault.factcheckinsights.local:3000) (MediaVault), or whatever URLs you chose. If not, contact @cguess or another developer.
 
 #### Starting the scraper
 

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -30,7 +30,7 @@ class ApplicantsController < ApplicationController
 
     decorated_params = applicant_params.merge({
       # Record what site the visitor is applying from
-      source_site: get_site_from_subdomain[:shortname],
+      source_site: get_site_from_host[:shortname],
       # Add the confirmation token the applicant uses to confirm their email address
       confirmation_token: Devise.friendly_token,
     })

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :null_session, if: :json_request?, prepend: true
 
-  before_action :set_site_from_subdomain
+  before_action :set_site_from_host
 
   sig { void }
   def index
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
     if site_is_media_vault?
       return media_vault_dashboard_path if user.can_access_media_vault?
 
-      # TODO: Lead to the Media Vault "Request Acces For Existing Insights User" page (#382)
+      # TODO: Lead to the Media Vault "Request Access For Existing Insights User" page (#382)
       return media_vault_root_path
     end
 
@@ -34,21 +34,21 @@ class ApplicationController < ActionController::Base
 
   sig { returns(T::Boolean) }
   def site_is_fact_check_insights?
-    get_site_from_subdomain == SiteDefinitions::FACT_CHECK_INSIGHTS
+    get_site_from_host == SiteDefinitions::FACT_CHECK_INSIGHTS
   end
 
   sig { returns(T::Boolean) }
   def site_is_media_vault?
-    get_site_from_subdomain == SiteDefinitions::MEDIA_VAULT
+    get_site_from_host == SiteDefinitions::MEDIA_VAULT
   end
 
 protected
 
-  # Returns which site is currently being requested based on subdomain.
+  # Returns which site is currently being requested based on host.
   # A little over-engineered, but prepared for future apps and for a different fallback default.
-  # But currently, falls back to Insights.
+  # Currently falls back to Insights.
   sig { returns(Hash) }
-  def get_site_from_subdomain
+  def get_site_from_host
     site = SiteDefinitions::BY_HOST[request.host]
     return site if site.present?
 
@@ -57,8 +57,8 @@ protected
   end
 
   sig { void }
-  def set_site_from_subdomain
-    @site = get_site_from_subdomain
+  def set_site_from_host
+    @site = get_site_from_host
   end
 
   sig { returns(T::Boolean) }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,22 +3,6 @@
 module ApplicationHelper
   include Pagy::Frontend
 
-  # Given a domain hostname, returns an array with each segment in reverse order: TLD first, then
-  # primary domain, then subdomains, then (optionally/rare) an environment.
-  # E.g., `"staging.www.example.com"` → `["com","example","www","staging"]`.
-  #
-  # Explicitly expects to operate on only the hostname, not the protocol, ports, path, etc.
-  def hostname_segments(hostname)
-    segments = hostname.split(".").reverse
-
-    {                           # E.g., `staging.www.example.com` generates:
-      tld:         segments[0], # "com"
-      primary:     segments[1], # "example"
-      subdomain:   segments[2], # "www"
-      environment: segments[3], # "staging" (will usually be `nil`)
-    }
-  end
-
   def make_title_tag_content(title_hierarchy = nil, opts = {
     delimeter: "•"
   })

--- a/app/mailers/account_mailer.rb
+++ b/app/mailers/account_mailer.rb
@@ -4,7 +4,7 @@ class AccountMailer < ApplicationMailer
     @token = params[:token]
 
     mail({
-      from: email_address_with_name("no-reply@mail.factcheckinsights.com", @site[:title]),
+      from: email_address_with_name("no-reply@#{Figaro.env.MAIL_DOMAIN}", @site[:title]),
       to: params[:user][:email],
       subject: "You’ve been approved for #{@site[:title]}!",
     })

--- a/app/mailers/applicants_mailer.rb
+++ b/app/mailers/applicants_mailer.rb
@@ -4,7 +4,7 @@ class ApplicantsMailer < ApplicationMailer
     @applicant = params[:applicant]
 
     mail({
-      from: email_address_with_name("no-reply@mail.factcheckinsights.com", @site[:title]),
+      from: email_address_with_name("no-reply@#{Figaro.env.MAIL_DOMAIN}", @site[:title]),
       to: @applicant[:email],
       subject: "Please confirm your email address for #{@site[:title]}"
     })

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # typed: false
 
 class ApplicationMailer < ActionMailer::Base
-  default from: email_address_with_name("no-reply@mail.factcheckinsights.com", "Fact-Check Insights")
+  default from: email_address_with_name("no-reply@#{Figaro.env.MAIL_DOMAIN}", "Fact-Check Insights")
   layout "mailer"
 end

--- a/app/views/account_mailer/setup_email.html.erb
+++ b/app/views/account_mailer/setup_email.html.erb
@@ -6,8 +6,8 @@
 	<body>
 		<p>Your request for access to <%= @site[:title] %> has been approved!</p>
 		<p>To complete your account setup, you’ll need to choose a password.</p>
-		<p><%= link_to "Click here to finish setting up your account", new_account_url(token: @token, host: @site[:url]) %>, or visit this URL in your browser:</p>
-		<pre><%= new_account_url(token: @token, host: @site[:url]) %></pre>
+		<p><%= link_to "Click here to finish setting up your account", new_account_url(token: @token, host: @site[:host]) %>, or visit this URL in your browser:</p>
+		<pre><%= new_account_url(token: @token, host: @site[:host]) %></pre>
 		<p>Thanks,</p>
 		<p>The Duke Reporters’ Lab Team</p>
 	</body>

--- a/app/views/account_mailer/setup_email.text.erb
+++ b/app/views/account_mailer/setup_email.text.erb
@@ -4,7 +4,7 @@ To complete your account setup, you’ll need to choose a password.
 
 Please visit this URL in your browser:
 
-<%= new_account_url(token: @token, host: @site[:url]) %>
+<%= new_account_url(token: @token, host: @site[:host]) %>
 
 Thanks,
 

--- a/app/views/applicants_mailer/confirmation_email.html.erb
+++ b/app/views/applicants_mailer/confirmation_email.html.erb
@@ -6,8 +6,8 @@
 	<body>
 		<p>Thanks for requesting access to <%= @site[:title] %>.</p>
 		<p>Before we can evaluate your application, you will need to confirm the email address you provided.</p>
-		<p><%= link_to "Click here to confirm your email address", applicant_confirm_url(email: @applicant[:email], token: @applicant[:confirmation_token], host: @site[:url]) %>, or visit this URL in your browser:</p>
-		<pre><%= applicant_confirm_url(email: @applicant[:email], token: @applicant[:confirmation_token], host: @site[:url]) %></pre>
+		<p><%= link_to "Click here to confirm your email address", applicant_confirm_url(email: @applicant[:email], token: @applicant[:confirmation_token], host: @site[:host]) %>, or visit this URL in your browser:</p>
+		<pre><%= applicant_confirm_url(email: @applicant[:email], token: @applicant[:confirmation_token], host: @site[:host]) %></pre>
 		<p>Thanks,</p>
 		<p>The Duke Reporters’ Lab Team</p>
 	</body>

--- a/app/views/applicants_mailer/confirmation_email.text.erb
+++ b/app/views/applicants_mailer/confirmation_email.text.erb
@@ -4,7 +4,7 @@ Before we can evaluate your application, you will need to confirm the email addr
 
 Please visit this URL in your browser:
 
-<%= applicant_confirm_url(email: @applicant[:email], token: @applicant[:confirmation_token], host: @site[:url]) %>
+<%= applicant_confirm_url(email: @applicant[:email], token: @applicant[:confirmation_token], host: @site[:host]) %>
 
 Thanks,
 

--- a/app/views/layouts/fact_check_insights/_header.html.erb
+++ b/app/views/layouts/fact_check_insights/_header.html.erb
@@ -32,7 +32,7 @@
 					<ol id="site-nav__account-menu" class="site-nav__links">
 						<% if current_user.can_access_media_vault? %>
 							<li>
-								<%= link_to SiteDefinitions::MEDIA_VAULT[:url], class: "btn btn--naked icon-prefixed" do %>
+								<%= link_to media_vault_root_url, class: "btn btn--naked icon-prefixed" do %>
 									<svg class="icon icon--lg"><use xlink:href="#svg-switch-lr"></use></svg>
 									<span><%= "Switch to #{SiteDefinitions::MEDIA_VAULT[:title]}" %></span>
 								<% end %>

--- a/app/views/layouts/media_vault/_header.html.erb
+++ b/app/views/layouts/media_vault/_header.html.erb
@@ -37,7 +37,7 @@
 					<% end %>
 					<ol id="site-nav__account-menu" class="site-nav__links">
 						<li>
-							<%= link_to SiteDefinitions::FACT_CHECK_INSIGHTS[:url], class: "btn btn--naked icon-prefixed" do %>
+							<%= link_to fact_check_insights_root_url, class: "btn btn--naked icon-prefixed" do %>
 								<svg class="icon icon--lg"><use xlink:href="#svg-switch-lr"></use></svg>
 								<span><%= "Switch to #{SiteDefinitions::FACT_CHECK_INSIGHTS[:title]}" %></span>
 							<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module Zenodotus
     config.action_mailer.delivery_method = :mailgun
     config.action_mailer.mailgun_settings = {
       api_key: Figaro.env.MAILGUN_API_KEY,
-      domain: "mail.factcheckinsights.com"
+      domain: Figaro.env.MAIL_DOMAIN,
     }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module Zenodotus
     #
     # Since this application hosts multiple sites, our URLs are context-specific, and so this will
     # often be over-ridden inline. However, we want to fall back to the primary Insights URL.
-    config.action_mailer.default_url_options = { host: Figaro.env.FACT_CHECK_INSIGHTS_URL }
+    config.action_mailer.default_url_options = { host: Figaro.env.FACT_CHECK_INSIGHTS_HOST }
 
     config.action_mailer.delivery_method = :mailgun
     config.action_mailer.mailgun_settings = {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,7 +70,6 @@ Rails.application.configure do
   # Prefix job queues names to avoid collisions
   config.active_job.queue_name_prefix = "zenodotus_development"
 
-  config.hosts << "www.factcheckinsights.local"
-  config.hosts << "vault.factcheckinsights.local"
-  config.hosts << "showoff-reporterslab.pagekite.me"
+  config.hosts << Figaro.env.FACT_CHECK_INSIGHTS_HOST
+  config.hosts << Figaro.env.MEDIA_VAULT_HOST
 end

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -12,7 +12,8 @@ Figaro.require_keys("HYPATIA_AUTH_KEY")
 Figaro.require_keys("FACT_CHECK_INSIGHTS_URL")
 Figaro.require_keys("MEDIA_VAULT_URL")
 
-# Mailgun settings for sending email
+# Settings for sending email
+Figaro.require_keys("MAIL_DOMAIN")
 Figaro.require_keys("MAILGUN_API_KEY")
 
 if Figaro.env.USE_S3_DEV_TEST == "true" || Rails.env == "production"

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -8,9 +8,9 @@ Figaro.require_keys("KEY_ENCRYPTION_SALT")
 Figaro.require_keys("HYPATIA_SERVER_URL")
 Figaro.require_keys("HYPATIA_AUTH_KEY")
 
-# The URL of the currently running server, used for configuring Action Mailer and Hypatia callbacks
-Figaro.require_keys("FACT_CHECK_INSIGHTS_URL")
-Figaro.require_keys("MEDIA_VAULT_URL")
+# The host names for the apps, used for routing requests to the appropriate app
+Figaro.require_keys("FACT_CHECK_INSIGHTS_HOST")
+Figaro.require_keys("MEDIA_VAULT_HOST")
 
 # Settings for sending email
 Figaro.require_keys("MAIL_DOMAIN")

--- a/config/initializers/site_definitions.rb
+++ b/config/initializers/site_definitions.rb
@@ -1,26 +1,14 @@
 class SiteDefinitions
-  # Given a domain such as `www.example.com`, returns the `www` portion.
-  #
-  # Note that this is not a generalizable method; it's based on our known domain pattern
-  # and would fail on something general like `www.example.co.uk`.
-  def self.extract_subdomain(url)
-    host = URI(url).host
-    host_segments = host.split(".").reverse
-    host_segments[2]
-  end
-
   FACT_CHECK_INSIGHTS = {
     shortname: "fact_check_insights",
     title: "Fact-Check Insights",
-    url: Figaro.env.FACT_CHECK_INSIGHTS_URL,
-    subdomain: self.extract_subdomain(Figaro.env.FACT_CHECK_INSIGHTS_URL),
+    host: Figaro.env.FACT_CHECK_INSIGHTS_HOST,
   }
 
   MEDIA_VAULT = {
     shortname: "media_vault",
     title: "MediaVault",
-    url: Figaro.env.MEDIA_VAULT_URL,
-    subdomain: self.extract_subdomain(Figaro.env.MEDIA_VAULT_URL),
+    host: Figaro.env.MEDIA_VAULT_HOST,
   }
 
   # This is for the meta-programming magic below.
@@ -34,15 +22,7 @@ class SiteDefinitions
     ALL.index_by { |site| site[attr] }.merge(ALL.index_by { |site| site[attr].to_sym })
   end
 
-  # Make the contents of ALL available by the hostname (which is a simplified version of the URL),
-  # in both string and symbol form.
-  def self.generate_index_by_host
-    ALL.index_by { |site| URI(site[:url]).host }.merge(ALL.index_by { |site| URI(site[:url]).host.to_sym })
-  end
-
   BY_SHORTNAME = self.generate_index_by(:shortname)
   BY_TITLE = self.generate_index_by(:title)
-  BY_URL = self.generate_index_by(:url)
-  BY_SUBDOMAIN = self.generate_index_by(:subdomain)
-  BY_HOST = self.generate_index_by_host()
+  BY_HOST = self.generate_index_by(:host)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
     get "/confirm/done", to: "applicants#confirmed", as: "applicant_confirmed"
   end
 
-  constraints subdomain: "www" do
+  constraints host: Figaro.env.FACT_CHECK_INSIGHTS_HOST do
     scope module: "fact_check_insights", as: "fact_check_insights" do
       root "application#index"
 
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
     end
   end
 
-  constraints subdomain: "vault" do
+  constraints host: Figaro.env.MEDIA_VAULT_HOST do
     scope module: "media_vault", as: "media_vault" do
       root "application#index"
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,9 @@
 
 ### Hosts
 
-This app serves two sites (Fact-Check Insights and MediaVault), each on their own subdomain. To dynamically serve the correct experience, you should no longer access the site via `http://localhost`, but via a locally-routed domains rooted at `factcheckinsights.local`.
+This app serves two sites (Fact-Check Insights and MediaVault), each on their own unique hosts configured via the `FACT_CHECK_INSIGHTS_HOST` and `MEDIA_VAULT_HOST` env vars. For authentication to be shared between the apps, this should be on the **same domain** but on **separate (unique) subdomains**.
+
+To dynamically serve the correct experience, you should no longer access the site via `http://localhost`, but via these custom domains. We recommend (but do not require) something like `factcheckinsights.local`, routed to localhost.
 
 Add the following entries to your `/etc/hosts` file:
 ```
@@ -15,18 +17,21 @@ Add the following entries to your `/etc/hosts` file:
 After starting the app, you will get to Insights via `http://www.factcheckinsights.local:3000` and to Vault via `http://vault.factcheckinsights.local:3000`. (If you setup your own local reverse proxy, you can do away with the `:3000` and/or setup HTTPS, as you wish.)
 
 ### Environment variables
+
 To run Zenodotus, you'll need to set the following environment variables. Ask a dev on the team to provide you access to them. 
+
 - `TWITTER_BEARER_TOKEN`
 - `HYPATIA_SERVER_URL`
 - `HYPATIA_AUTH_KEY`
 - `secret_key_base` (Devise secret)
 - `KEY_ENCRYPTION_SALT`
-- `FACT_CHECK_INSIGHTS_URL`, e.g. `http://www.factcheckinsights.local:3000`
-- `MEDIA_VAULT_URL`, e.g. `http://vault.factcheckinsights.local:3000`
+- `FACT_CHECK_INSIGHTS_HOST`, e.g. `www.factcheckinsights.local`
+- `MEDIA_VAULT_HOST`, e.g. `vault.factcheckinsights.local`
 - `MAIL_DOMAIN`, e.g. `mail.factcheckinsights.org`
 - `MAILGUN_API_KEY`
 
 Optional
+
 - `USE_S3_DEV_TEST` If set to `"true"` (the string) the software will use S3 as a storage backend
   exactly the same as in production (except the bucket is set to clear itself every 24 hours).
   If set you will be required to also set `AWS_ACCESS_KEY` and `AWS_ACCESS_SECRET`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -23,6 +23,8 @@ To run Zenodotus, you'll need to set the following environment variables. Ask a 
 - `KEY_ENCRYPTION_SALT`
 - `FACT_CHECK_INSIGHTS_URL`, e.g. `http://www.factcheckinsights.local:3000`
 - `MEDIA_VAULT_URL`, e.g. `http://vault.factcheckinsights.local:3000`
+- `MAIL_DOMAIN`, e.g. `mail.factcheckinsights.org`
+- `MAILGUN_API_KEY`
 
 Optional
 - `USE_S3_DEV_TEST` If set to `"true"` (the string) the software will use S3 as a storage backend

--- a/test/controllers/applicants_controller_test.rb
+++ b/test/controllers/applicants_controller_test.rb
@@ -105,7 +105,7 @@ class ApplicantsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "can record that an applicant came from the Vault application page" do
-    host! "vault.factcheckinsights.local"
+    host! Figaro.env.MEDIA_VAULT_HOST
 
     post applicants_path(applicant: {
       name: "Jane Doe",

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -3,14 +3,14 @@
 require "test_helper"
 
 class ApplicationControllerTest < ActionDispatch::IntegrationTest
-  test "can recognize the Insights subdomain" do
+  test "can recognize the Insights host" do
     host! "www.factcheckinsights.local"
     get root_url
 
     assert @controller.site_is_fact_check_insights?
   end
 
-  test "can recognize the Vault subdomain" do
+  test "can recognize the Vault host" do
     host! "vault.factcheckinsights.local"
     get root_url
 

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -3,15 +3,23 @@
 require "test_helper"
 
 class ApplicationControllerTest < ActionDispatch::IntegrationTest
+  test "must have unique hosts for each app" do
+    all_hosts = SiteDefinitions::ALL.pluck(:host)
+
+    assert_equal all_hosts.uniq, all_hosts
+  end
+
+  # If this test fails, it is likely because you do not have a unique host for Insights,
+  # and so the Vault definition is overwriting.
   test "can recognize the Insights host" do
-    host! "www.factcheckinsights.local"
+    host! Figaro.env.FACT_CHECK_INSIGHTS_HOST
     get root_url
 
     assert @controller.site_is_fact_check_insights?
   end
 
   test "can recognize the Vault host" do
-    host! "vault.factcheckinsights.local"
+    host! Figaro.env.MEDIA_VAULT_HOST
     get root_url
 
     assert @controller.site_is_media_vault?

--- a/test/controllers/media_vault/archive_controller_test.rb
+++ b/test/controllers/media_vault/archive_controller_test.rb
@@ -7,7 +7,7 @@ class MediaVault::ArchiveControllerTest < ActionDispatch::IntegrationTest
   include Minitest::Hooks
 
   setup do
-    host! "vault.factcheckinsights.local"
+    host! Figaro.env.MEDIA_VAULT_HOST
   end
 
   def around

--- a/test/controllers/media_vault/facebook_users_controller_test.rb
+++ b/test/controllers/media_vault/facebook_users_controller_test.rb
@@ -6,7 +6,7 @@ class MediaVault::FacebookUsersControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
-    host! "vault.factcheckinsights.local"
+    host! Figaro.env.MEDIA_VAULT_HOST
   end
 
   test "cannot view Facebook user if logged out" do

--- a/test/controllers/media_vault/image_search_controller_test.rb
+++ b/test/controllers/media_vault/image_search_controller_test.rb
@@ -6,7 +6,7 @@ class MediaVault::ImageSearchControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
-    host! "vault.factcheckinsights.local"
+    host! Figaro.env.MEDIA_VAULT_HOST
   end
 
   test "must be logged in to view image search" do

--- a/test/controllers/media_vault/ingest_controller_test.rb
+++ b/test/controllers/media_vault/ingest_controller_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class MediaVault::IngestControllerTest < ActionDispatch::IntegrationTest
   setup do
-    host! "vault.factcheckinsights.local"
+    host! Figaro.env.MEDIA_VAULT_HOST
   end
 
   test "Submitting an API request without a key will return 401 error" do

--- a/test/controllers/media_vault/instagram_users_controller_test.rb
+++ b/test/controllers/media_vault/instagram_users_controller_test.rb
@@ -6,7 +6,7 @@ class MediaVault::InstagramUsersControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
-    host! "vault.factcheckinsights.local"
+    host! Figaro.env.MEDIA_VAULT_HOST
   end
 
   test "cannot view Instagram user if logged out" do

--- a/test/controllers/media_vault/text_search_controller_test.rb
+++ b/test/controllers/media_vault/text_search_controller_test.rb
@@ -6,7 +6,7 @@ class MediaVault::TextSearchControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
-    host! "vault.factcheckinsights.local"
+    host! Figaro.env.MEDIA_VAULT_HOST
   end
 
   test "must be logged in to view text search" do

--- a/test/controllers/media_vault/twitter_users_controller_test.rb
+++ b/test/controllers/media_vault/twitter_users_controller_test.rb
@@ -6,7 +6,7 @@ class MediaVault::TwitterUsersControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
-    host! "vault.factcheckinsights.local"
+    host! Figaro.env.MEDIA_VAULT_HOST
   end
 
   test "cannot view Twitter user if logged out" do

--- a/test/controllers/media_vault/youtube_channels_controller_test.rb
+++ b/test/controllers/media_vault/youtube_channels_controller_test.rb
@@ -6,7 +6,7 @@ class MediaVault::YoutubeChannelsControllerTest < ActionDispatch::IntegrationTes
   include Devise::Test::IntegrationHelpers
 
   setup do
-    host! "vault.factcheckinsights.local"
+    host! Figaro.env.MEDIA_VAULT_HOST
   end
 
   test "cannot view YouTube channel if logged out" do

--- a/test/controllers/media_vault_controller_test.rb
+++ b/test/controllers/media_vault_controller_test.rb
@@ -4,7 +4,7 @@ class MediaVaultControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
-    host! "vault.factcheckinsights.local"
+    host! Figaro.env.MEDIA_VAULT_HOST
   end
 
   test "should not allow Insights-only users to view dashboard" do


### PR DESCRIPTION
This PR replaces the `*_URL` versions of the env vars for our apps (e.g. `http://vault.factcheckinsights.local:3000`) with `*_HOST` versions (e.g., `vault.factcheckinsights.local`). It also removes the assumption/restriction that they fit the `{subdomain}.factcheckinsights.local` pattern.

It also also:
- Removes an unused utility method (`hostname_segments`) that's even less useful now that we aren't following any prescribed hostname format
- Fixes the vestigial name of some methods to change `*_subdomain` to `*_host`
- Makes better use of some existing URL helpers
- Slips in a change to env-var-ify the domain we use for sending email (#401)

**Setup:**

Make the following changes to your ENV vars (`application.yml` or otherwise), substituting whatever hosts you want for the `*_HOST` vars (PageKite, whatever):

```diff
- URL
- FACT_CHECK_INSIGHTS_URL
- MEDIA_VAULT_URL
+ FACT_CHECK_INSIGHTS_HOST: "www.factcheckinsights.local"
+ MEDIA_VAULT_HOST: "vault.factcheckinsights.local"
+ MAIL_DOMAIN: "mail.factcheckinsights.com"
```

⚠️ If you want to feed two birds with one stone or whatever, you can set `MAIL_DOMAIN` to `mail.factcheckinsights.org` and grab its accompanying API key (for `MAILGUN_API_KEY`) from 1Password labeled "Mailgun API (FCI/Development)". We'll leave the .com version alive a little longer, but will be transitioning entirely over to .org by launch. All the previous .com versions of the keys have been archived in 1Password, so what's visible is all-.org.

**Testing:**
- `rails t`
- `rails s` and poke around, particularly logging in as a MediaVault-enabled user (or the admin) and making sure you can switch back and forth between Insights and Vault using the same authentication session.

Closes #397 
Closes #401 