### PR TITLE
Stub out Insights data download with empty JSON

### DIFF
--- a/app/controllers/fact_check_insights_controller.rb
+++ b/app/controllers/fact_check_insights_controller.rb
@@ -7,7 +7,25 @@ class FactCheckInsightsController < ApplicationController
   def index; end
 
   sig { void }
-  def download; end
+  def download
+    respond_to do |format|
+      format.html do; end
+      format.json do
+        unless user_signed_in? && current_user.can_access_fact_check_insights?
+          render json: {
+            error: "You do not have permission to view that resource."
+          }, status: :unauthorized
+          return
+        end
+
+        # TODO: Fill this out with real data.
+        send_data({}.to_json,
+          type: "application/json",
+          filename: "fact_check_insights.json"
+        )
+      end
+    end
+  end
 
   sig { void }
   def guide; end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -87,6 +87,11 @@ class User < ApplicationRecord
   end
 
   sig { returns(T::Boolean) }
+  def can_access_fact_check_insights?
+    self.is_admin? || self.is_fact_check_insights_user?
+  end
+
+  sig { returns(T::Boolean) }
   def can_access_media_vault?
     self.is_admin? || self.is_media_vault_user?
   end

--- a/app/views/fact_check_insights/download.html.erb
+++ b/app/views/fact_check_insights/download.html.erb
@@ -1,3 +1,12 @@
 <% @title_tag = "Download the Data" %>
 
-Download the Data
+<p>The Fact-Check Insights dataset includes information about tens of thousands of fact-checks published by fact-checking organizations around the world. Most of the information in the dataset dates from 2016 to the present, and the dataset is updated with new entries every day. Each item includes a URL for the published fact-check, as well as information about the statement being checked, the speaker, the location, the conclusion the fact-checker reached about the statement’s veracity, and more.</p>
+<p>This data is intended for download by academics, researchers, journalists, fact-checkers and others who plan to use it for research and development purposes.</p>
+
+<% if user_signed_in? %>
+	<%= link_to "Download JSON", fact_check_insights_download_path(format: :json), class: "btn btn--orange" %>
+	<p>The compilation of this data is licensed under <%= link_to "CC BY", "https://creativecommons.org/licenses/by/4.0/" %>.</p>
+	<p>Need your organization’s data removed from the dataset? If you’d like for us to remove your organization’s data from the dataset, please email <%= mail_to "help@factcheckinsights.org", subject: "Remove organization from Fact-Check Insights data" %> and let us know.</p>
+<% else %>
+	<%= link_to "Request Access", new_applicant_path, class: "btn btn--orange" %>
+<% end %>


### PR DESCRIPTION
This PR adds the wiring for generating a secure JSON download for users authorized to download Insights data.

- Add `can_access_fact_check_insights?` user method that goes beyond the proxying of “all users are Insights users” to make it explicit
- Add copy to Download page (but without good styling)
- Add JSON endpoint to download page, secured by authorization check, that generates an empty dataset for now.

Issue #275