### PR TITLE
Send a notification when a scrape is done

### DIFF
--- a/app/controllers/media_vault/ingest_controller.rb
+++ b/app/controllers/media_vault/ingest_controller.rb
@@ -79,7 +79,6 @@ class MediaVault::IngestController < MediaVaultController
     response_payload = archive_from_media_review(media_review_json)
 
     render(json: response_payload, status: response_payload.has_key?(:error) ? 400 : 200)
-
   rescue JSON::ParserError
     response_payload = {
       error_code: ApiErrors::JSONParseError.code,
@@ -169,6 +168,7 @@ class MediaVault::IngestController < MediaVaultController
     } unless validate_media_review(media_review_json)
 
     saved_object = ArchiveItem.create_from_media_review(media_review_json)
+
     {
       response_code: ApiResponseCodes::Success.code,
       response: ApiResponseCodes::Success.message,

--- a/app/models/scrape.rb
+++ b/app/models/scrape.rb
@@ -46,6 +46,9 @@ class Scrape < ApplicationRecord
       media_review_item.update({ archive_item_id: archive_item.first.id, taken_down: false })
       self.update!({ fulfilled: true, archive_item: archive_item.first })
     end
+
+    # Update any channels listening to the scrape count
+    send_notification
   end
 
   sig { void }


### PR DESCRIPTION
We somehow forgot to update the `scrapes` channel when a scrape is fulfilled. This fixes that.

To test:
Unfortunately the only way to test this is to launch a Hypatia instance and go through the whole thing of scraping and waiting for a callback. The code that's called is already in production use, so maybe we just say "ok" to it ;-)`

Closes #410