### PR TITLE
Resolve JS importing issues in production mode

### DIFF
--- a/app/javascript/controllers/jobs_status_controller.js
+++ b/app/javascript/controllers/jobs_status_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
-import consumer from '../channels/consumer';
+import consumer from 'channels/consumer'
 
 export default class extends Controller {
   static targets = ['scrapesPill', 'scrapesCount', 'jobsCount']

--- a/app/javascript/controllers/media_vault/archive_controller.js
+++ b/app/javascript/controllers/media_vault/archive_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
-import { humanizeTimeElement } from '../../utilities'
+import { humanizeTimeElement } from 'utilities'
 
 export default class extends Controller {
   static targets = [

--- a/app/javascript/controllers/media_vault/author_controller.js
+++ b/app/javascript/controllers/media_vault/author_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
-import { humanizeTimeElement } from '../../utilities'
+import { humanizeTimeElement } from 'utilities'
 
 export default class extends Controller {
   static targets = [

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,5 +1,6 @@
 # Pin npm packages by running ./bin/importmap
 pin "application", preload: true
+pin "utilities", preload: true
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true


### PR DESCRIPTION
This PR should resolve the issue with some JavaScript not loading correctly in production environments.

We weren't importing some files using the correct syntax, and also hadn't added one of our core files to the importmap.

**Prerequisites:**

If you've never run the app locally in production mode before, then you'll have to do a couple of things:
- Set `RAILS_SERVE_STATIC_FILES: "true"` in your `application.yml` or env vars.
- Configure the `production` block of `database.yml` for your setup. I just copied the `development` block and then ran `RAILS_ENV=production rails db:setup`.

**Testing:**
1. On the `master` branch:
   1. `rm -r public/assets`
   2. `RAILS_ENV=production rails assets:precompile`
   3. `RAILS_ENV=production rails s`
   4. Load the app in-browser with your development console open
   5. :x: You should see a couple of 404s for the `utilities` and `channels/consumer` files, plus a bunch of `Failed to register controller` errors. (This is wrong, but expected.)
1. Switch to this `418-resolve-js-issues` branch
   1. **Repeat all those steps**, except this time…
   2. ✅ You should see no console errors.
   
Closes #418