### PR TITLE
Fact Check Insights exports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -183,3 +183,6 @@ gem "tailwindcss-rails", "~> 2.0"
 
 # We use SCSS to write more CSS more concisely
 gem "dartsass-rails", "~> 0.4.0"
+
+# Comma lets us generate CSV-formatted data from ActiveRecord models
+gem "comma", "~>4.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
     childprocess (4.1.0)
     climate_control (0.2.0)
     coderay (1.1.3)
+    comma (4.7.0)
+      activesupport (>= 4.2.0)
     commander (4.6.0)
       highline (~> 2.0.0)
     concurrent-ruby (1.1.10)
@@ -491,6 +493,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara (>= 3.26)
+  comma (~> 4.7.0)
   country_select (~> 8.0)
   dartsass-rails (~> 0.4.0)
   devise (~> 4.8.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -143,4 +143,12 @@ protected
       redirect_back_or_to "/", allow_other_host: false, alert: "You don’t have permission to access that page."
     end
   end
+
+  sig { returns(String) }
+  def render_unauthorized
+    render file: "#{Rails.root}/public/401.html",
+      layout: false,
+      content_type: "text/html",
+      status: :unauthorized
+  end
 end

--- a/app/controllers/fact_check_insights_controller.rb
+++ b/app/controllers/fact_check_insights_controller.rb
@@ -18,21 +18,10 @@ class FactCheckInsightsController < ApplicationController
           return
         end
 
-        send_data(generate_json,
-          type: "application/json",
-          filename: "fact_check_insights_data.json"
-        )
+        send_data(generate_json, type: "application/json", filename: "fact_check_insights.json")
       end
-      format.zip do
-        unless user_signed_in? && current_user.can_access_fact_check_insights?
-          render "You do not have permission to view that resource.", status: :unauthorized
-          return
-        end
 
-        send_data(generate_csv_zips,
-          type: "application/zip",
-          filename: "fact_check_insights_data.zip"
-        )
+      format.zip do
       end
     end
   end
@@ -56,12 +45,19 @@ private
 
   sig { returns(String) }
   def generate_json
-    # TODO: Fill this out with real data. #275
-    {}.to_json
+    all_claim_reviews = ClaimReview.all.map { |claim_review| JSON.parse(claim_review.render_for_export) }
+    all_media_reviews = MediaReview.all.map { |media_review| JSON.parse(media_review.render_for_export) }
+    metadata = {
+      "retrievedAt": Time.now,
+      "claimReviewCount": all_claim_reviews.length,
+      "mediaReviewCount": all_media_reviews.length
+    }
+
+    JSON.pretty_generate({ "claimReviews": all_claim_reviews, "mediaReviews": all_media_reviews, "meta": metadata })
   end
 
   sig { returns(T::Boolean) }
-  def generate_csv_zips
+  def generate_csv_zip
     # TODO: Fill this out with real data. #275
     true
   end

--- a/app/controllers/fact_check_insights_controller.rb
+++ b/app/controllers/fact_check_insights_controller.rb
@@ -22,9 +22,7 @@ class FactCheckInsightsController < ApplicationController
 
       format.zip do
         unless user_signed_in? && current_user.can_access_fact_check_insights?
-          render json: {
-            error: "You do not have permission to view that resource."
-          }, status: :unauthorized
+          render_unauthorized
           return
         end
         send_data(FactCheckInsightsController.generate_csv_zip, type: "application/zip", filename: "fact_check_insights.zip")

--- a/app/controllers/fact_check_insights_controller.rb
+++ b/app/controllers/fact_check_insights_controller.rb
@@ -17,7 +17,7 @@ class FactCheckInsightsController < ApplicationController
           }, status: :unauthorized
           return
         end
-        send_data(generate_json, type: "application/json", filename: "fact_check_insights.json")
+        send_data(FactCheckInsightsController.generate_json, type: "application/json", filename: "fact_check_insights.json")
       end
 
       format.zip do
@@ -27,7 +27,7 @@ class FactCheckInsightsController < ApplicationController
           }, status: :unauthorized
           return
         end
-        send_data(generate_csv_zip, type: "application/zip", filename: "fact_check_insights.zip")
+        send_data(FactCheckInsightsController.generate_csv_zip, type: "application/zip", filename: "fact_check_insights.zip")
       end
     end
   end
@@ -51,7 +51,7 @@ private
 
   # Generate a JSON-formatted string of ClaimReview and MediaReview data
   sig { returns(String) }
-  def generate_json
+  def self.generate_json
     all_claim_reviews = ClaimReview.all.map { |claim_review| JSON.parse(claim_review.render_for_export) }
     all_media_reviews = MediaReview.all.map { |media_review| JSON.parse(media_review.render_for_export) }
     metadata = {
@@ -65,7 +65,7 @@ private
 
   # Generate a CSV-formatted string of ClaimReview and MediaReview data
   sig { returns(String) }
-  def generate_csv_zip
+  def self.generate_csv_zip
     compressed_filestream = Zip::OutputStream.write_buffer(::StringIO.new("")) do |zos|
       zos.put_next_entry "claim_reviews.csv"
       claim_review_csv = ClaimReview.all.to_comma

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -2,7 +2,8 @@ class ClaimReview < ApplicationRecord
   validates :media_review_id, presence: true
   belongs_to :media_review, optional: true, class_name: "MediaReview"
 
-  def to_json
+  sig { returns(String) }
+  def render_for_export
     ClaimReviewBlueprint.render(self)
   end
 end

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -2,6 +2,36 @@ class ClaimReview < ApplicationRecord
   validates :media_review_id, presence: true
   belongs_to :media_review, optional: true, class_name: "MediaReview"
 
+  # CSV export formatting
+  comma do
+    url "url"
+    claim_reviewed "claimReviewed"
+    date_published "datePublished" do |date_published| date_published.strftime("%Y-%m-%d") end
+    __static_column__ "@context" do "https://schema.org" end
+    __static_column__ "@type" do "ClaimReview" end
+
+    author "author_@type" do |author| author["@type"] end
+    author "author_name" do |author| author["name"] end
+    author "author_url" do |author| author["url"] end
+    author "author_image" do |author| author["image"] end
+    author "author_sameAs" do |author| author["sameAs"] end
+
+    review_rating "reviewRating_@type" do |review_rating| review_rating["@type"] end
+    review_rating "reviewRating_ratingValue" do |review_rating| review_rating["ratingValue"] end
+    review_rating "reviewRating_bestRating" do |review_rating| review_rating["bestRating"] end
+    review_rating "reviewRating_image" do |review_rating| review_rating["image"] end
+    review_rating "reviewRating_alternateName" do |review_rating| review_rating["alternateName"] end
+
+    item_reviewed "itemReviewed_@type" do |item_reviewed| item_reviewed["@type"] end
+    item_reviewed "itemReviewed_datePublished" do |item_reviewed| item_reviewed["datePublished"] end
+    item_reviewed "itemReviewed_name" do |item_reviewed| item_reviewed["name"] end
+    item_reviewed "itemReviewed_author_@type" do |item_reviewed| item_reviewed.dig("author", "@type") end
+    item_reviewed "itemReviewed_author_name" do |item_reviewed| item_reviewed.dig("author", "name") end
+    item_reviewed "itemReviewed_author_jobTitle" do |item_reviewed| item_reviewed.dig("author", "jobTitle") end
+    item_reviewed "itemReviewed_author_image" do |item_reviewed| item_reviewed.dig("author", "image") end
+    item_reviewed "itemReviewed_author_sameAs" do |item_reviewed| item_reviewed.dig("author", "sameAs") end
+  end
+
   sig { returns(String) }
   def render_for_export
     ClaimReviewBlueprint.render(self)

--- a/app/models/media_review.rb
+++ b/app/models/media_review.rb
@@ -19,7 +19,8 @@ class MediaReview < ApplicationRecord
     archive_item.nil?
   end
 
-  def to_json
+  sig { returns(String) }
+  def render_for_export
     MediaReviewBlueprint.render(self)
   end
 end

--- a/app/models/media_review.rb
+++ b/app/models/media_review.rb
@@ -10,9 +10,49 @@ class MediaReview < ApplicationRecord
   validates :media_authenticity_category, presence: true
   validates :url, presence: true
 
-
   # All media review without an attached piece of archive
   scope :orphaned, -> { where("archive_item_id = ?", nil) }
+
+  # CSV export formatting
+  comma do
+    url "url"
+    media_authenticity_category "mediaAuthenticityCategory"
+    original_media_context_description "originalMediaContextDescription"
+    date_published "datePublished" do |date_published| date_published.strftime("%Y-%m-%d") end
+    __static_column__ "@context" do "https://schema.org" end
+    __static_column__ "@type" do "MediaReview" end
+
+    author "author_@type" do |author| author["@type"] end
+    author "author_name" do |author| author["name"] end
+    author "author_url" do |author| author["url"] end
+    author "author_image" do |author| author["image"] end
+    author "author_sameAs" do |author| author["sameAs"] end
+
+    item_reviewed "itemReviewed_@type" do |item_reviewed| item_reviewed["@type"] end
+    item_reviewed "itemReviewed_creator_@type" do |item_reviewed| item_reviewed.dig("creator", "@type") end
+    item_reviewed "itemReviewed_creator_name" do |item_reviewed| item_reviewed.dig("creator", "name") end
+    item_reviewed "itemReviewed_creator_url" do |item_reviewed| item_reviewed.dig("creator", "url") end
+    item_reviewed "itemReviewed_interpretedAsClaim_@type" do |item_reviewed| item_reviewed.dig("interpretedAsClaim", "@type") end
+    item_reviewed "itemReviewed_interpretedAsClaim_description" do |item_reviewed| item_reviewed.dig("interpretedAsClaim", "description") end
+
+
+    # The CSV representation of a MediaReview will only include a single object from the mediaItemAppearance array
+    # Namely, the object containing the `contentUrl` attribute
+    item_reviewed "itemReviewed_mediaItemAppearance_@type" do |item_reviewed|
+      appearance = item_reviewed.dig("mediaItemAppearance").filter { |appearance| appearance.has_key?("contentUrl") }.first
+      appearance["@type"]
+    end
+
+    item_reviewed "itemReviewed_mediaItemAppearance_contentUrl" do |item_reviewed|
+      appearance = item_reviewed.dig("mediaItemAppearance").filter { |appearance| appearance.has_key?("contentUrl") }.first
+      appearance["contentUrl"]
+    end
+
+    item_reviewed "itemReviewed_mediaItemAppearance_archivedAt" do |item_reviewed|
+      appearance = item_reviewed.dig("mediaItemAppearance").filter { |appearance| appearance.has_key?("contentUrl") }.first
+      appearance["archivedAt"]
+    end
+  end
 
   sig { returns(Boolean) }
   def orphaned?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -134,7 +134,9 @@ media_review = MediaReview.create(
   author: {
     "@type": "Organization",
     "name": "realfact",
-    "url": "https://realfact.com"
+    "url": "https://realfact.com",
+    "image": "https://i.kym-cdn.com/photos/images/newsfeed/001/207/210/b22.jpg",
+    "sameAs": "https://twitter.com/realfact"
   },
   media_authenticity_category: "TransformedContent",
   original_media_context_description: "Star Wars Ipsum",
@@ -178,9 +180,14 @@ MediaReview.create(
     "url": "https://realfact.com"
   },
   media_authenticity_category: "TransformedContent",
-  original_media_context_description: "Star Wars Ipsum",
+  original_media_context_description: "Batman Ipsum",
   item_reviewed: {
     "@type": "MediaReviewItem",
+    "creator": {
+      "@type": "Person",
+      "name": "Name Nameson",
+      "url": "https://user2.com/"
+    },
     "embeddedTextCaption": "But we’ve met before. That was a long time ago, I was a kid at St. Swithin’s, It used to be funded by the Wayne Foundation",
     "interpretedAsClaim": {
       "@type": "Claim",
@@ -214,6 +221,11 @@ MediaReview.create(
   media_authenticity_category: "TransformedContent",
   item_reviewed: {
     "@type": "MediaReviewItem",
+    "creator": {
+      "@type": "Person",
+      "name": "User",
+      "url": "https://user.com/"
+    },
     "interpretedAsClaim": {
       "@type": "Claim",
       "description": "claim description"
@@ -245,19 +257,20 @@ ClaimReview.create(
   date_published: "2021-02-01",
   item_reviewed: {
     "@type": "Claim",
+    "datePublished": "2021-01-30",
+    "name": "Star Wars claim",
     "author": {
       "@type": "Person",
       "jobTitle": "On the internet",
       "name": "Viral image"
     },
-    "datePublished": "2021-01-30"
   },
   review_rating: {
     "@type": "Rating",
-    "alternateName": "False",
-    "bestRating": "9",
     "ratingValue": "4",
-    "worstRating": "0"
+    "bestRating": "5",
+    "image": "https://static.politifact.com/politifact/rulings/meter-false.jpg",
+    "alternateName": "False"
   },
   url: "https://www.realfact.com/factchecks/2021/feb/03/starwars",
   media_review: media_review

--- a/public/401.html
+++ b/public/401.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>You are not authorized to access that resource (401)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  .rails-default-error-page {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  .rails-default-error-page div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  .rails-default-error-page div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  .rails-default-error-page h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  .rails-default-error-page div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body class="rails-default-error-page">
+  <!-- This file lives in public/401.html -->
+  <div class="dialog">
+    <div>
+      <h1>You are not authorized to access that resource.</h1>
+      <p>Either you aren't logged in, or your account doesn't have the necessary permissions to view that page (or file, or whatever). Try starting over <a href="/">back at the home page</a>, logging in if necessary.
+      <p>If you keep having trouble, please <a href="/contact">get in touch</a>.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/test/controllers/fact_check_insights_controller_test.rb
+++ b/test/controllers/fact_check_insights_controller_test.rb
@@ -5,8 +5,8 @@ class FactCheckInsightsControllerTest < ActionDispatch::IntegrationTest
 
   # Create an ArchiveItem, a MediaReview object, and a ClaimReview object
   def before_all
-    return if File.exist?("tmp/") && File.directory?(Forki.temp_storage_location)
-    FileUtils.mkdir_p "/tmp"
+    return if File.exist?("tmp/") && File.directory?("tmp/")
+    FileUtils.mkdir_p("tmp/")
 
     media_review = MediaReview.create!(
       original_media_link: "https://www.foobar.com/1",

--- a/test/controllers/fact_check_insights_controller_test.rb
+++ b/test/controllers/fact_check_insights_controller_test.rb
@@ -1,7 +1,102 @@
 require "test_helper"
 
 class FactCheckInsightsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  include Minitest::Hooks
+
+  # Create an ArchiveItem, a MediaReview object, and a ClaimReview object
+  def before_all
+    return if File.exist?("tmp/") && File.directory?(Forki.temp_storage_location)
+    FileUtils.mkdir_p "/tmp"
+
+    media_review = MediaReview.create!(
+      original_media_link: "https://www.foobar.com/1",
+      date_published: "2021-02-03",
+      url: "https://www.realfact.com/factchecks/2021/feb/03/starwars",
+      author: {
+        "@type": "Organization",
+        "name": "realfact",
+        "url": "https://realfact.com",
+        "image": "https://i.kym-cdn.com/photos/images/newsfeed/001/207/210/b22.jpg",
+        "sameAs": "https://twitter.com/realfact"
+      },
+      media_authenticity_category: "TransformedContent",
+      original_media_context_description: "Star Wars Ipsum",
+      item_reviewed: {
+        "@type": "MediaReviewItem",
+        "creator": {
+          "@type": "Person",
+          "name": "Old Ben-Kenobi",
+          "url": "https://www.foobar.com/x/1"
+        },
+        "interpretedAsClaim": {
+          "@type": "Claim",
+          "description": "Two droids on the imperial watchlist entered a hovercraft"
+        },
+        "embeddedTextCaption": "Your droids. They’ll have to wait outside. We don’t want them here. Listen, why don’t you wait out by the speeder. We don’t want any trouble.",
+        "mediaItemAppearance": [
+          {
+            "@type": "ImageObjectSnapshot",
+            "description": "A stormtrooper posted a screenshot of two droids entering a hovercraft",
+            "sha256sum": ["8bb6caeb301b85cddc7b67745a635bcda939d17044d9bcf31158ef5e9f8ff072"],
+            "accessedOnUrl": "https://www.facebook.com/photo.php?fbid=10217541425752089&set=a.1391489831857&type=3",
+            "archivedAt": "https://archive.is/dfype"
+          },
+          {
+            "@type": "ImageObjectSnapshot",
+            "contentUrl": "https://www.foobar.com/1",
+            "archivedAt": "www.archive.org"
+          }
+        ]
+      },
+    )
+
+    ClaimReview.create!(
+      author: {
+        "@type": "Organization",
+        "name": "realfact",
+        "url": "https://www.realfact.com/"
+      },
+      claim_reviewed: "The approach will not be easy. You are required to maneuver straight down this trench and skim the surface to this point. The target area is only two meters wide.",
+      date_published: "2021-02-01",
+      item_reviewed: {
+        "@type": "Claim",
+        "datePublished": "2021-01-30",
+        "name": "Star Wars claim",
+        "author": {
+          "@type": "Person",
+          "jobTitle": "On the internet",
+          "name": "Viral image"
+        },
+      },
+      review_rating: {
+        "@type": "Rating",
+        "ratingValue": "4",
+        "bestRating": "5",
+        "image": "https://static.politifact.com/politifact/rulings/meter-false.jpg",
+        "alternateName": "False"
+      },
+      url: "https://www.realfact.com/factchecks/2021/feb/03/starwars",
+      media_review: media_review
+    )
+  end
+
+  test "can generate Fact Check Insights JSON export" do
+    json_export = JSON.parse(FactCheckInsightsController.generate_json)
+    assert json_export["meta"]["mediaReviewCount"].positive?
+    assert json_export["meta"]["claimReviewCount"].positive?
+  end
+
+
+  # Generate a csv zip file, write it to disk, read it, then validate it
+  test "can generate Fact Check Insights csv zip export" do
+    zipped_csvs = FactCheckInsightsController.generate_csv_zip
+    File.binwrite("tmp/csvs.zip", zipped_csvs)
+
+    claim_reviews = nil
+    media_reviews = nil
+    Zip::File.open("tmp/csvs.zip") do |zip_file|
+      claim_reviews = CSV.parse(zip_file.glob("claim_reviews.csv").first.get_input_stream.read)
+      media_reviews = CSV.parse(zip_file.glob("media_reviews.csv").first.get_input_stream.read)
+    end
+  end
 end

--- a/test/models/claim_review_test.rb
+++ b/test/models/claim_review_test.rb
@@ -73,7 +73,7 @@ class ClaimReviewTest < ActiveSupport::TestCase
         "datePublished" => "2021-01-30"
       }
     }
-    claim_review_json = JSON.parse(claim_review.to_json) # call blueprinter
+    claim_review_json = JSON.parse(claim_review.render_for_export) # call blueprinter
     assert_equal expected, claim_review_json
   end
 

--- a/test/models/media_review_test.rb
+++ b/test/models/media_review_test.rb
@@ -92,7 +92,7 @@ class MediaReviewTest < ActiveSupport::TestCase
         ]
       }
     }
-    media_review_json = JSON.parse(media_review.to_json) # call blueprinter
+    media_review_json = JSON.parse(media_review.render_for_export) # call blueprinter
     assert_equal expected, media_review_json
   end
 end


### PR DESCRIPTION
This PR adds `MediaReview`/`ClaimReview` data export functionality to Zenodotus. It uses `BluePrinters` specs created per #390 and #391 to generate JSON exports and a new gem, `comma`, to generate CSV exports. 

The CSV exports are a bit hairy, because they're flat representations of nested data. Column names in the CSV use use underscores to denote nested attributes. 

For example, data corresponding to the `reviewRating.ratingValue` attribute will be written to a  column named `reviewRating_ratingValue`. 

Closes #275 

# Testing instructions
- `bundle` (install `comma`)
- `rake`
- Log into FCI and try out the CSV and JSON data downloads. Make sure the data in the downloaded files matches the data in our `seeds.rb` file. Try loading the download URLs without being logged in. You shouldn't get any data :)
 