### PR TITLE
Add MediaVault Guide copy and Opt-Out instructions

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,6 +28,7 @@
 @use "pages/fact_check_insights_guide";
 @use "pages/fact_check_insights_highlights";
 @use "pages/media_vault_home";
+@use "pages/media_vault_guide";
 
 #site-wrapper {
 	display: flex;

--- a/app/assets/stylesheets/colors.scss
+++ b/app/assets/stylesheets/colors.scss
@@ -57,5 +57,5 @@ body {
 }
 
 .bg--blue {
-	background-color: shared.$color--dark;
+	background-color: shared.$color--brand--claim-review;
 }

--- a/app/assets/stylesheets/containers.scss
+++ b/app/assets/stylesheets/containers.scss
@@ -69,3 +69,12 @@
 		max-width: shared.$screen-xl-ceiling;
 	}
 }
+
+.full-bleed-headline {
+	@extend .full-bleed;
+
+	&.reversed {
+		background-color: shared.$color--dark;
+		color: white;
+	}
+}

--- a/app/assets/stylesheets/pages/media_vault_guide.scss
+++ b/app/assets/stylesheets/pages/media_vault_guide.scss
@@ -1,0 +1,5 @@
+@use "shared";
+
+#page--media_vault--guide {
+	background-color: shared.$color--brand--fact-check-insights;
+}

--- a/app/assets/stylesheets/pages/media_vault_home.scss
+++ b/app/assets/stylesheets/pages/media_vault_home.scss
@@ -1,5 +1,5 @@
 @use "shared";
 
-#page--media_vault--index {
+#page--media_vault--home {
 	background-color: shared.$color--brand--media-vault;
 }

--- a/app/views/application/contact.html.erb
+++ b/app/views/application/contact.html.erb
@@ -4,10 +4,8 @@
 	<div class="lg:basis-2/4">
 		<div class="max-w-2xl">
 			<h1>Let's stay in touch</h1>
-			<p class="b1 ">For questions about the <%= @site[:title] %> data, please email us at <%= mail_to "hello@factcheckinsights.org" %>.</p>
-			<% if site_is_fact_check_insights?(@site) %>
-				<p><%= link_to "Need your organization’s data removed from the dataset?", fact_check_insights_optout_path %></p>
-			<% end %>
+			<p class="b1">For questions about the <%= @site[:title] %> data, please email us at <%= mail_to "hello@factcheckinsights.org" %>.</p>
+			<p class="b2"><%= render partial: "#{@site[:shortname]}/optout_instructions" %></p>
 		</div>
 	</div>
 	<div class="lg:basis-2/4 flex justify-center">

--- a/app/views/fact_check_insights/_optout_instructions.html.erb
+++ b/app/views/fact_check_insights/_optout_instructions.html.erb
@@ -1,0 +1,9 @@
+If you’d like for us to remove your organization’s data from the dataset, please <%= mail_to "hello@factcheckinsights.org", "fill out this email form", {
+	subject: "Fact-Check Insights data opt-out request",
+	body: "I would like to request that my organization's data be excluded from the Fact-Check Insights data export file.
+
+Organization name:
+My name:
+My role within the organization:
+Reason for request:"
+} %>.

--- a/app/views/fact_check_insights/download.html.erb
+++ b/app/views/fact_check_insights/download.html.erb
@@ -14,7 +14,7 @@
 				<%= link_to "Download JSON", fact_check_insights_download_path(format: :json), class: "btn btn--orange btn--lg" %>
 				<%= link_to "Download CSV", fact_check_insights_download_path(format: :zip), class: "btn btn--orange btn--lg" %>
 			</div>
-			<p>The compilation of this data is licensed under <%= link_to "CC BY", "https://creativecommons.org/licenses/by/4.0/" %>. <%= link_to "Need your organization’s data removed from the dataset?", fact_check_insights_optout_path %></p>
+			<p>The compilation of this data is licensed under <%= link_to "CC BY", "https://creativecommons.org/licenses/by/4.0/" %>. <%= render partial: "optout_instructions" %></p>
 		<% else %>
 			<h2>Access is free, but registration is required.</h2>
 			<%= link_to "Request Access", new_applicant_path, class: "btn btn--orange" %> <%= link_to "Log in", new_user_session_path, class: "btn" %>

--- a/app/views/fact_check_insights/guide.html.erb
+++ b/app/views/fact_check_insights/guide.html.erb
@@ -38,7 +38,7 @@
 			<h2>Where do the data come from?</h2>
 			<p class="b2">Fact-checkers at organizations all over the world enter ClaimReview data every time they publish a fact-check. The organizations included in this dataset are limited to those appearing in the <%= link_to "Duke Reporters’ Lab database", "https://reporterslab.org/fact-checking/" %> of global fact-checking sites.</p>
 			<p class="b2">The Lab tracks hundreds of nonpartisan organizations that regularly publish articles, videos or audio reports that verify claims made by politicians, debunk social media rumors and hoaxes, and/or review political promises made by candidates or parties. <%= link_to "Visit the Reporters’ Lab site", "https://reporterslab.org/how-we-identify-fact-checkers/" %> for more information on how we determine which organizations to include. (Note: Not all organizations in the Reporters’ Lab database use ClaimReview.)</p>
-			<p><%= link_to "Need your organization’s data removed from the dataset?", fact_check_insights_optout_path %></p>
+			<p><%= render partial: "optout_instructions" %></p>
 		</div>
 	</div>
 </div>

--- a/app/views/fact_check_insights/optout.html.erb
+++ b/app/views/fact_check_insights/optout.html.erb
@@ -2,5 +2,5 @@
 
 <div class="content content--md">
 	<h1>Opt Out</h1>
-	<p class="b1">If you’d like for us to remove your organization’s data from the dataset, please email <%= mail_to "hello@factcheckinsights.org", subject: "Remove organization from Fact-Check Insights data" %> and let us know.</p>
+	<p class="b1"><%= render partial: "optout_instructions" %></p>
 </div>

--- a/app/views/layouts/media_vault/_header.html.erb
+++ b/app/views/layouts/media_vault/_header.html.erb
@@ -19,7 +19,7 @@
 			<ol id="site-nav__primary" class="site-nav__links">
 				<% if current_user.can_access_media_vault? %>
 					<li><%= link_to media_vault_dashboard_path, class: "btn btn--naked" do %><span>Dashboard</span><% end %></li>
-					<li><%= link_to media_vault_guide_path, class: "btn btn--naked" do %><span>Guide</span><% end %></li>
+					<li><%= link_to media_vault_guide_path, class: "btn btn--naked" do %><span>Guide<span class="hideable"> to MediaVault</span></span><% end %></li>
 					<li><%= link_to media_vault_text_search_path, class: "btn btn--naked" do %><span>Text Search</span><% end %></li>
 					<li><%= link_to media_vault_image_search_path, class: "btn btn--naked" do %><span>Media Search</span><% end %></li>
 					<li><%= link_to media_vault_archive_add_path, class: "btn" do %><span>Add URL</span><% end %></li>

--- a/app/views/media_vault/_optout_instructions.html.erb
+++ b/app/views/media_vault/_optout_instructions.html.erb
@@ -1,0 +1,9 @@
+If you’d like for us to remove your organization’s data from the dataset, please <%= mail_to "hello@factcheckinsights.org", "fill out this email form", {
+	subject: "MediaVault data opt-out request",
+	body: "I would like to request that my organization's data be excluded from MediaVault.
+
+Organization name:
+My name:
+My role within the organization:
+Reason for request:"
+} %>.

--- a/app/views/media_vault/archive/index.html.erb
+++ b/app/views/media_vault/archive/index.html.erb
@@ -1,3 +1,5 @@
+<% @page_id = "dashboard" %>
+
 <%= turbo_frame_tag "modal" %>
 
 <div class="hidden container mx-auto my-4 shadow rounded-lg bg-white py-5">

--- a/app/views/media_vault/guide.html.erb
+++ b/app/views/media_vault/guide.html.erb
@@ -1,3 +1,77 @@
 <% @title_tag = "Guide to MediaVault" %>
 
-Guide
+<div class="full-bleed-headline">
+	<div class="contain content">
+		<h2>What is MediaVault?</h2>
+	</div>
+</div>
+<div class="lg:flex lg:gap-20 lg:mb-0">
+	<div class="content lg:basis-2/4 b2">
+		<p class="b1">MediaVault is an unprecedented archive of images, videos and memes that have been analyzed by reputable fact-checking organizations from around the world.</p>
+		<p>Our cutting-edge system scrapes and stores content from social media platforms and other sources that would otherwise disappear completely if it is deleted or removed. With MediaVault, fact-checkers can preserve the content that they have fact-checked in its original form. That content then becomes searchable, so other fact-checkers can easily determine if a given image or video has been fact-checked before.</p>
+		<p>MediaVault provides long-term accessibility and durability for archiving, research and more rapid detection of misleading images and video.</p>
+	</div>
+	<div class="hidden lg:flex lg:place-items-center lg:place-content-center lg:basis-2/4 lg:p-20 bg--media-vault">
+		<div class="masked-image masked-image--media-vault max-w-xs w-full">
+			<%= image_tag "photos/cameras.jpg" %>
+		</div>
+	</div>
+</div>
+
+<div class="full-bleed-headline reversed">
+	<div class="contain content">
+		<h2>What descriptive data is included with MediaVault entries?</h2>
+	</div>
+</div>
+<div class="content">
+	<div class="lg:flex lg:gap-20 b2">
+		<p class="lg:basis-2/4">MediaVault entries are collected when fact-checkers use a tagging system known as MediaReview that allows them to identify whether a video, image, or meme has been manipulated. Fact-checkers provide basic information — for example, the URL where the piece of media was found, and the URL of their fact-checking article — as well as an assessment of whether the media was manipulated. (For more on these assessments, see “How do fact-checkers assess MediaVault content?” below.)</p>
+		<p class="lg:basis-2/4">Along with the MediaReview tagging data, most MediaVault entries also contain data from ClaimReview, a sibling to MediaReview used by fact-checkers to rate claims regardless of format. ClaimReview includes information about the statement being checked, the source of the claim, the location, the date, the conclusion the fact-checker reached about the statement’s veracity, and more.</p>
+	</div>
+	<p class="mt-10 text-center b1">For more information about ClaimReview and MediaReview, visit <%= link_to "The ClaimReview Project", "https://www.claimreviewproject.com/", class: "bg--blue" %>.</p>
+</div>
+
+
+<div class="full-bleed-headline reversed">
+	<div class="contain content">
+		<h2>How do fact-checkers assess MediaVault content?</h2>
+	</div>
+</div>
+<div class="content">
+	<p class="b2">Fact-checking organizations around the world all use their own systems for identifying and checking potential misinformation found online. But when they enter their fact-checks into MediaReview, they use a standardized ratings format for identifying whether an individual piece of media has been manipulated. Those ratings are:</p>
+	<dl class="mt-20 grid grid-cols lg:grid-cols-3 lg:grid-rows-2 gap-10">
+		<div>
+			<dt class="h4">Original</dt>
+			<dd>No evidence the image or video has been misleadingly altered or manipulated, though it may still contain false or misleading claims.</dd>
+		</div>
+		<div>
+			<dt class="h4">Missing Context</dt>
+			<dd>Presenting unaltered images or video in an inaccurate manner to mislead the viewer. For example, labeling with incorrect dates or locations. (An image or video rated “original” can also be missing context.)</dd>
+		</div>
+		<div>
+			<dt class="h4">Cropped or Edited</dt>
+			<dd>Presenting a part of an image from a larger whole, or editing or rearranging a video, to mislead the viewer.</dd>
+		</div>
+		<div>
+			<dt class="h4">Transformed</dt>
+			<dd>Adding or deleting visual elements to give an image a different meaning with the intention to mislead, or manipulating video footage in ways such as changing speed, dubbing audio or altering visual elements. This rating includes deepfake videos.</dd>
+		</div>
+		<div>
+			<dt class="h4">Staged</dt>
+			<dd>An image or video that was created using actors or similarly contrived.</dd>
+		</div>
+		<div>
+			<dt class="h4">Satire/Parody</dt>
+			<dd>An image or video that was created as political or humorous commentary and is presented in that context.</dd>
+		</div>
+	</dl>
+</div>
+
+<div class="full-bleed bg--media-vault">
+	<div class="contain">
+		<div class="content content--md">
+			<h2>How do I exclude my data from MediaVault?</h2>
+			<p class="b2"><%= render partial: "optout_instructions" %></p>
+		</div>
+	</div>
+</div>

--- a/app/views/media_vault/index.html.erb
+++ b/app/views/media_vault/index.html.erb
@@ -1,3 +1,4 @@
+<% @page_id = "home" %>
 
 <div class="content lg:flex lg:items-center lg:gap-20">
 	<div class="lg:basis-2/4 b2">

--- a/app/views/media_vault/optout.html.erb
+++ b/app/views/media_vault/optout.html.erb
@@ -2,4 +2,5 @@
 
 <div class="content content--md">
 	<h1>Opt Out</h1>
+	<p class="b1"><%= render partial: "optout_instructions" %></p>
 </div>


### PR DESCRIPTION
This PR delivers the last of the MediaVault copy (Guide) and makes the opt-out instructions consistent across all uses. It also adds the ability to generate an opt-out email with prefilled instructions.

While more design-related stuff will come up, this is enough to deliver #267 and move on to smaller issues.

Closes #267 
Closes #422