### PR TITLE
Add applicant management page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @use "header";
 @use "icons";
 @use "images";
+@use "tables";
 @use "typography";
 
 // Entity components
@@ -23,6 +24,7 @@
 
 // Pages
 @use "pages/about";
+@use "pages/admin_applicants";
 @use "pages/fact_check_insights_home";
 @use "pages/fact_check_insights_download";
 @use "pages/fact_check_insights_guide";

--- a/app/assets/stylesheets/authors.scss
+++ b/app/assets/stylesheets/authors.scss
@@ -38,7 +38,6 @@ a.author:hover .author__username {
 	align-self: flex-start;
 	aspect-ratio: 1 / 1;
 	width: var(--author--profile-image-size);
-	height: 100%;
 
 	transition-property: width;
 }

--- a/app/assets/stylesheets/pages/admin_applicants.scss
+++ b/app/assets/stylesheets/pages/admin_applicants.scss
@@ -1,0 +1,68 @@
+@use "shared";
+
+#page--fact_check_insights--applicants,
+#page--media_vault--applicants {
+	background-color: shared.$color--brand--fact_check_insights;
+
+	.applicants {
+		display: grid;
+		gap: 2rem;
+		margin-bottom: 5rem;
+
+		font-family: shared.$font-family--sans-serif;
+		line-height: 1.2;
+
+		@media screen and (min-width: shared.$screen-xl-floor) {
+			grid-template-columns: 1fr 1fr;
+		}
+	}
+
+	.applicant {
+		width: 100%;
+	}
+
+	.applicant__details {
+		display: grid;
+		gap: 1rem;
+		font-size: 1.1rem;
+
+		@media screen and (min-width: shared.$screen-md-floor) {
+			grid-template-columns: 1fr 1fr;
+		}
+	}
+
+	.applicant__detail {
+		> dt {
+			font-weight: shared.$font-weight--semibold;
+			font-size: 0.9em;
+		}
+
+		> dd {
+			.na {
+				color: lightgray;
+			}
+		}
+
+		&.applicant__detail--full-width {
+			grid-column: 1 / -1;
+		}
+	}
+
+	.applicant__actions {
+		.form {
+			margin-top: 3rem;
+		}
+	}
+
+	.applicant__status {
+		font-weight: shared.$font-weight--semibold;
+
+		&.applicant__status--approved {
+			color: shared.$color--mood--success;
+		}
+
+		&.applicant__status--rejected {
+			color: shared.$color--mood--error;
+		}
+	}
+}

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -1,0 +1,58 @@
+@use "shared";
+
+.table {
+	--table--border-color: lightgray;
+	--table--cell-padding-y: 0.5em;
+	--table--cell-padding-x: 0;
+
+	width: 100%;
+
+	font-family: shared.$font-family--sans-serif, sans-serif;
+	line-height: 1.2;
+
+	thead {
+		tr {
+			border-bottom: 1px solid var(--table--border-color);
+		}
+
+		th {
+			font-weight: shared.$font-weight--semibold;
+			vertical-align: bottom;
+		}
+	}
+
+	tbody {
+		tr {
+			border-bottom: 1px solid var(--table--border-color);
+		}
+
+		th {
+			text-align: right;
+		}
+
+		th,
+		td {
+			vertical-align: top;
+		}
+	}
+
+	th,
+	td {
+		text-align: left;
+		padding: var(--table--cell-padding-y) var(--table--cell-padding-x);
+		transition-property: padding;
+
+		.center {
+			text-align: center;
+		}
+
+		.right {
+			text-align: right;
+		}
+	}
+
+	@media screen and (min-width: shared.$screen-lg-floor) {
+		--table--cell-padding-y: 0.5em;
+		--table--cell-padding-x: 0.5em;
+	}
+}

--- a/app/assets/stylesheets/typography.scss
+++ b/app/assets/stylesheets/typography.scss
@@ -94,3 +94,8 @@ a:hover {
 .color--danger {
 	color: shared.$color--mood--error;
 }
+
+.subtle {
+	color: gray;
+	font-weight: shared.$font-weight--light;
+}

--- a/app/controllers/admin/applicants_controller.rb
+++ b/app/controllers/admin/applicants_controller.rb
@@ -17,6 +17,7 @@ class Admin::ApplicantsController < AdminController
     @applicant = Applicant.find(review_params[:id])
 
     @applicant.approve(
+      reviewer: current_user,
       review_note: review_params[:review_note],
       review_note_internal: review_params[:review_note_internal],
     )
@@ -33,6 +34,7 @@ class Admin::ApplicantsController < AdminController
     @applicant = Applicant.find(review_params[:id])
 
     @applicant.reject(
+      reviewer: current_user,
       review_note: review_params[:review_note],
       review_note_internal: review_params[:review_note_internal],
     )

--- a/app/controllers/admin/applicants_controller.rb
+++ b/app/controllers/admin/applicants_controller.rb
@@ -1,0 +1,53 @@
+# typed: strict
+
+class Admin::ApplicantsController < AdminController
+  sig { void }
+  def index
+    @unreviewed_applicants = Applicant.unreviewed.order(created_at: :desc)
+    @reviewed_applicants = Applicant.reviewed.order(reviewed_at: :desc)
+  end
+
+  sig { void }
+  def show
+    @applicant = Applicant.find(params[:id])
+  end
+
+  sig { void }
+  def approve
+    @applicant = Applicant.find(review_params[:id])
+
+    @applicant.approve(
+      review_note: review_params[:review_note],
+      review_note_internal: review_params[:review_note_internal],
+    )
+
+    user = User.create_from_applicant(@applicant)
+    user.send_setup_instructions
+
+    flash[:success] = "Applicant has been approved."
+    redirect_to admin_applicants_path
+  end
+
+  sig { void }
+  def reject
+    @applicant = Applicant.find(review_params[:id])
+
+    @applicant.reject(
+      review_note: review_params[:review_note],
+      review_note_internal: review_params[:review_note_internal],
+    )
+
+    flash[:success] = "Applicant has been rejected."
+    redirect_to admin_applicants_path
+  end
+
+private
+
+  def review_params
+    params.permit(
+      :id,
+      :review_note,
+      :review_note_internal,
+    )
+  end
+end

--- a/app/helpers/admin/applicants_helper.rb
+++ b/app/helpers/admin/applicants_helper.rb
@@ -1,0 +1,5 @@
+module Admin::ApplicantsHelper
+  def or_na(text)
+    text.present? ? text : '<span class="na">n/a</span>'.html_safe
+  end
+end

--- a/app/javascript/controllers/admin/applicants_controller.js
+++ b/app/javascript/controllers/admin/applicants_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from '@hotwired/stimulus'
+import { humanizeTimeElement } from 'utilities'
+
+export default class extends Controller {
+  static targets = [
+    'timestamp',
+  ]
+
+  timestampTargetConnected(element) {
+    humanizeTimeElement(element)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,12 +5,6 @@ import { application } from "controllers/application"
 // Eager load all controllers defined in the import map under controllers/**/*_controller
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
 eagerLoadControllersFrom("controllers", application)
-// Note: This should not be necessary. I'm unsure why it is necessary.
-//       In fact, it's a little troubling that it *is* necessary.
-//       It's further troubling that the controllers inside `controllers/{dir}` are not
-//       namespaced as `{dir}--{name}` the way we would totally expect. Much troubling.
-eagerLoadControllersFrom("controllers/admin", application)
-eagerLoadControllersFrom("controllers/media_vault", application)
 
 // Lazy load controllers as they appear in the DOM (remember not to preload controllers in import map!)
 // import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -113,6 +113,16 @@ class Applicant < ApplicationRecord
     self.status.nil?
   end
 
+  sig { returns(T.self_type) }
+  def self.unreviewed
+    Applicant.where(status: nil).where.not(confirmed_at: nil)
+  end
+
+  sig { returns(T.self_type) }
+  def self.reviewed
+    Applicant.where.not(status: nil).where.not(confirmed_at: nil)
+  end
+
 private
 
   sig { void }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,12 @@ class User < ApplicationRecord
   has_many :image_searches, dependent: :destroy
   has_many :text_searches, dependent: :destroy
 
+  # This is the applicant that the user was created from.
+  # I.e., this is the user's own application.
   has_one :applicant, dependent: :destroy
+
+  # These are the applicants that this user has reviewed.
+  has_many :applicants, foreign_key: :reviewer_id, dependent: :nullify
 
   validates :name, presence: true
   validates :email, presence: true

--- a/app/views/admin/applicants/index.html.erb
+++ b/app/views/admin/applicants/index.html.erb
@@ -1,0 +1,135 @@
+<% @title_tag = "Applicants" %>
+<% @page_id = "applicants" %>
+
+<div class="content" data-controller="admin--applicants">
+	<h1>Applicants</h1>
+
+	<% if @unreviewed_applicants.any? %>
+	<div class="applicants applicants--unreviewed">
+		<% @unreviewed_applicants.each do |applicant| %>
+			<div class="applicant box">
+				<dl class="applicant__details">
+					<div class="applicant__detail">
+						<dt>Name</dt>
+						<dd><%= applicant.name  %></dd>
+					</div>
+					<div class="applicant__detail">
+						<dt>Email</dt>
+						<dd><%= mail_to applicant.email %></dd>
+					</div>
+					<div class="applicant__detail">
+						<dt>Affiliation</dt>
+						<dd><%= or_na(applicant.affiliation) %></dd>
+					</div>
+					<div class="applicant__detail">
+						<dt>Primary role</dt>
+						<dd><%= or_na(applicant.primary_role) %></dd>
+					</div>
+					<div class="applicant__detail">
+						<dt>Applied for</dt>
+						<dd><%= SiteDefinitions::BY_SHORTNAME[applicant.source_site][:title] %></dd>
+					</div>
+					<div class="applicant__detail">
+						<dt>Applied at</dt>
+						<dd>
+								<time
+									datetime="<%= applicant.created_at.iso8601 %>"
+									data-admin--applicants-target="timestamp"
+									><%= applicant.created_at %></time>
+						</dd>
+					</div>
+					<div class="applicant__detail">
+						<dt>Use case</dt>
+						<dd><%= applicant.use_case %></dd>
+					</div>
+					<div class="applicant__detail">
+						<dt>Country</dt>
+						<dd><%= or_na(applicant.country) %></dd>
+					</div>
+				</dl>
+				<div class="applicant__actions">
+					<%= form_with(
+						class: "form"
+					) do |f| %>
+						<%= f.hidden_field :id, value: applicant.id %>
+						<div class="fieldset__fields">
+							<div class="field__wrapper--input">
+								<%= f.label(
+									:review_note_internal,
+									"🔒 Internal review note *") %>
+								<%= f.text_area(
+									:review_note_internal,
+									size: "50x3",
+									required: true) %>
+								<div class="field__description">Share information with other admins about this applicant, your reasons for approving or rejecting, etc.</div>
+							</div>
+							<div class="field__wrapper--input hidden">
+								<%= f.label(
+									:review_note,
+									"🗣 Reply to applicant") %>
+								<%= f.text_area(
+									:review_note,
+									size: "50x3") %>
+								<div class="field__description"><b class="color--danger">Be careful!</b> Whatever you type here will be sent to the applicant.</div>
+							</div>
+						</div>
+						<div class="btn-container flex justify-evenly">
+							<%= f.submit(
+								"Approve",
+								formaction: admin_applicant_approve_path(applicant),
+								class: "btn btn--submit") %>
+							<%= f.submit(
+								"Reject",
+								formaction: admin_applicant_reject_path(applicant),
+								class: "btn btn--danger") %>
+						</div>
+					<% end %>
+				</div>
+			</div>
+		<% end %>
+	</div>
+	<% else %>
+		<p class="b1" style="margin-bottom:4rem;">There are currently no unreviewed applicants.</p>
+	<% end %>
+
+	<h2>Reviewed applicants</h2>
+
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Name</th>
+				<th>Affiliation</th>
+				<th>Primary role</th>
+				<th>Use case</th>
+				<th>Country</th>
+				<th>Applied for</th>
+				<th>Status</th>
+			</tr>
+		</thead>
+		<tbody>
+		<% @reviewed_applicants.each do |applicant| %>
+			<tr>
+				<td>
+					<%= applicant.name %><br>
+					<%= mail_to applicant.email, class: "subtle" %>
+				</td>
+				<td><%= applicant.affiliation %></td>
+				<td><%= applicant.primary_role %></td>
+				<td><%= applicant.use_case %></td>
+				<td><%= applicant.country %></td>
+				<td><%= SiteDefinitions::BY_SHORTNAME[applicant.source_site][:title] %></td>
+				<td>
+					<span class="applicant__status applicant__status--<%= applicant.status %>">
+						<%= applicant.status.capitalize %>
+					</span>
+					on
+					<time
+						datetime="<%= applicant.reviewed_at.iso8601 %>"
+						data-admin--applicants-target="timestamp"
+						><%= applicant.reviewed_at %></time>
+				</td>
+			</tr>
+		<% end %>
+		</tbody>
+	</table>
+</div>

--- a/app/views/admin/applicants/index.html.erb
+++ b/app/views/admin/applicants/index.html.erb
@@ -127,6 +127,7 @@
 						datetime="<%= applicant.reviewed_at.iso8601 %>"
 						data-admin--applicants-target="timestamp"
 						><%= applicant.reviewed_at %></time>
+					by <%= applicant.reviewer.name %>
 				</td>
 			</tr>
 		<% end %>

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -5,6 +5,7 @@
 	<h1>Admin</h1>
 
 	<ul>
+		<li><%= link_to "Applicants", admin_applicants_path %></li>
 		<li><%= link_to "Jobs Status", admin_jobs_status_root_path %></li>
 	</ul>
 </div>

--- a/app/views/media_vault/archive/_archive_item.html.erb
+++ b/app/views/media_vault/archive/_archive_item.html.erb
@@ -10,7 +10,7 @@
 <div
     class="<%= archive_item_class_list %>"
     data-publishing-platform="<%= publishing_platform_shortname %>"
-    data-controller="archive"
+    data-controller="media-vault--archive"
     data-archive-caption-collapse-mode-value="<%= caption_is_collapsable ? 'collapsed' : 'static' %>"
 >
   <div class="archive-item__inner">
@@ -50,14 +50,14 @@
         <div class="archive-item__body-caption">
             <div
                 class="archive-item__body-caption-content"
-                data-archive-target="captionContent"
+                data-media-vault--archive-target="captionContent"
             >
                 <%= linkify_urls_in_text(simple_format(archive_item_caption)) %>
             </div>
             <% if caption_is_collapsable %>
                 <button
                     class="archive-item__body-caption-toggler"
-                    data-archive-target="captionToggler"
+                    data-media-vault--archive-target="captionToggler"
                     data-action="archive#toggleCaption"
                     data-collapse-label="Collapse caption ↑"
                     data-expand-label="Expand caption ↓"
@@ -73,7 +73,7 @@
               <time
                   class="archive-item__metadatum__value"
                   datetime="<%= published_at.iso8601 %>"
-                  data-archive-target="timestamp"
+                  data-media-vault--archive-target="timestamp"
               >
                   <%= published_at %>
               </time>
@@ -84,7 +84,7 @@
             <time
                 class="archive-item__metadatum__value"
                 datetime="<%= archived_at.iso8601 %>"
-                data-archive-target="timestamp"
+                data-media-vault--archive-target="timestamp"
             >
                 <%= archived_at %>
             </time>

--- a/app/views/media_vault/facebook_users/show.html.erb
+++ b/app/views/media_vault/facebook_users/show.html.erb
@@ -1,4 +1,4 @@
-<div class="author" data-controller="author">
+<div class="author" data-controller="media-vault--author">
   <img
     class="author__image"
     src="<%= @facebook_user.profile_image_url %>"

--- a/app/views/media_vault/image_search/_results.html.erb
+++ b/app/views/media_vault/image_search/_results.html.erb
@@ -7,4 +7,4 @@
     <%= render partial: partial_name, locals: { result: result } %>
   <% end %>
 <% end %>
-<div data-controller="image-search" id="search-id" data-search-id="<%= search.id %>" data-image-search-search-id="<%= search.id %>" ></div>
+<div data-controller="media-vault--image-search" id="search-id" data-search-id="<%= search.id %>" data-image-search-search-id="<%= search.id %>" ></div>

--- a/app/views/media_vault/image_search/index.html.erb
+++ b/app/views/media_vault/image_search/index.html.erb
@@ -3,7 +3,7 @@
     <div class="font-display text-xl">Media Search</div>
   </div>
   <div class="mt-4 mx-1">
-  <%= form_for @search, url: media_vault_image_search_submit_path, class: "w-full max-w-sm", html: { data: { controller: "image-search", action: "submit->image-search#onPostSend turbo:submit-end->image-search#onPostSuccess" } } do |form| %>
+  <%= form_for @search, url: media_vault_image_search_submit_path, class: "w-full max-w-sm", html: { data: { controller: "media-vault--image-search", action: "submit->image-search#onPostSend turbo:submit-end->image-search#onPostSuccess" } } do |form| %>
     <div class="md:flex md:items-center mb-6">
       <div class="md:w-1/4">
         <%= form.label :image_to_search_for, "Media to search by:", class: "block text-gray-500 md:text-right mb-1 md:mb-0 pr-4" %>

--- a/app/views/media_vault/instagram_users/show.html.erb
+++ b/app/views/media_vault/instagram_users/show.html.erb
@@ -1,4 +1,4 @@
-<div class="author" data-controller="author">
+<div class="author" data-controller="media-vault--author">
   <img
     class="author__image"
     src="<%= @instagram_user.profile_image_url %>"

--- a/app/views/media_vault/twitter_users/show.html.erb
+++ b/app/views/media_vault/twitter_users/show.html.erb
@@ -1,4 +1,4 @@
-<div class="author" data-controller="author">
+<div class="author" data-controller="media-vault--author">
   <img
     class="author__image"
     src="<%= @twitter_user.profile_image_url %>"
@@ -29,7 +29,7 @@
           Joined Twitter on
           <time
             datetime="<%= @twitter_user.sign_up_date.iso8601 %>"
-            data-author-target="timestamp"
+            data-media-vault--author-target="timestamp"
           >
             <%= @twitter_user.sign_up_date %>
           </time>

--- a/app/views/media_vault/youtube_channels/show.html.erb
+++ b/app/views/media_vault/youtube_channels/show.html.erb
@@ -1,4 +1,4 @@
-<div class="author" data-controller="author">
+<div class="author" data-controller="media-vault--author">
   <img
     class="author__image"
     src="<%= @youtube_channel.channel_image_url %>"
@@ -29,7 +29,7 @@
           Channel created on
           <time
             datetime="<%= @youtube_channel.sign_up_date.iso8601 %>"
-            data-author-target="timestamp"
+            data-media-vault--author-target="timestamp"
           >
             <%= @youtube_channel.sign_up_date %>
           </time>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,12 +1,14 @@
 # Pin npm packages by running ./bin/importmap
-pin "application", preload: true
-pin "utilities", preload: true
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin "@rails/actioncable", to: "actioncable.esm.js"
 pin "@rails/activestorage", to: "activestorage.esm.js"
-pin_all_from "app/javascript/channels", under: "channels"
-pin_all_from "app/javascript/controllers", under: "controllers"
 pin "dayjs" # @1.11.5
 pin "dayjs/plugin/utc", to: "dayjs--plugin--utc.js" # @1.11.5
+
+# Our JavaScript
+pin "application", preload: true
+pin "utilities", preload: true
+pin_all_from "app/javascript/channels", under: "channels"
+pin_all_from "app/javascript/controllers", under: "controllers"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,10 @@ Rails.application.routes.draw do
       delete ":id", action: "delete_scrape", as: "delete"
       post "resubmit/:id", action: "resubmit_scrape", as: "resubmit"
     end
+
+    resources :applicants, only: [:index, :show]
+    post "applicants/:id/approve", to: "applicants#approve", as: "applicant_approve"
+    post "applicants/:id/reject", to: "applicants#reject", as: "applicant_reject"
   end
 
   constraints host: Figaro.env.FACT_CHECK_INSIGHTS_HOST do

--- a/db/migrate/20221104070857_add_reviewer_to_applicants.rb
+++ b/db/migrate/20221104070857_add_reviewer_to_applicants.rb
@@ -1,0 +1,5 @@
+class AddReviewerToApplicants < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :applicants, :reviewer, index: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_17_212322) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_04_070857) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -51,7 +51,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_17_212322) do
     t.text "review_note_internal"
     t.uuid "user_id"
     t.string "source_site"
+    t.uuid "reviewer_id"
     t.index ["confirmation_token"], name: "index_applicants_on_confirmation_token", unique: true
+    t.index ["reviewer_id"], name: "index_applicants_on_reviewer_id"
     t.index ["user_id"], name: "index_applicants_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -69,6 +69,8 @@ Applicant.create!([
     confirmed_at: Time.now,
     source_site: SiteDefinitions::FACT_CHECK_INSIGHTS[:shortname],
     status: "rejected",
+    reviewed_at: Time.now,
+    reviewer: admin,
   },
   # This applicant is approved, but hasn't yet been converted to a user.
   {
@@ -80,6 +82,8 @@ Applicant.create!([
     confirmed_at: Time.now,
     source_site: SiteDefinitions::FACT_CHECK_INSIGHTS[:shortname],
     status: "approved",
+    reviewed_at: Time.now,
+    reviewer: admin,
   },
   # This applicant is approved and will be converted to a standard Insights user.
   {
@@ -91,6 +95,8 @@ Applicant.create!([
     confirmed_at: Time.now,
     source_site: SiteDefinitions::FACT_CHECK_INSIGHTS[:shortname],
     status: "approved",
+    reviewed_at: Time.now,
+    reviewer: admin,
   },
   # This applicant is approved and will be converted to a standard Vault user.
   {
@@ -102,6 +108,8 @@ Applicant.create!([
     confirmed_at: Time.now,
     source_site: SiteDefinitions::MEDIA_VAULT[:shortname],
     status: "approved",
+    reviewed_at: Time.now,
+    reviewer: admin,
   },
 ])
 

--- a/test/controllers/admin/applicants_controller_test.rb
+++ b/test/controllers/admin/applicants_controller_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class Admin::ApplicantsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    sign_in users(:admin)
+  end
+
+  test "can approve applicant" do
+    applicant = applicants(:confirmed)
+
+    assert_not applicant.approved?
+    post admin_applicant_approve_path(id: applicant[:id])
+    applicant.reload
+    assert applicant.approved?
+  end
+
+  test "can reject applicant" do
+    applicant = applicants(:confirmed)
+
+    assert_not applicant.rejected?
+    post admin_applicant_reject_path(id: applicant[:id])
+    applicant.reload
+    assert applicant.rejected?
+  end
+
+  test "cannot review an applicant with an unconfirmed email" do
+    applicant = applicants(:new)
+
+    assert_not applicant.confirmed?
+    assert_raises Applicant::UnconfirmedError do
+      post admin_applicant_approve_path(id: applicant[:id])
+    end
+    applicant.reload
+    assert_not applicant.approved?
+  end
+
+  test "cannot reject an already-approved applicant" do
+    applicant = applicants(:approved)
+
+    assert applicant.approved?
+    assert_raises Applicant::StatusChangeError do
+      post admin_applicant_reject_path(id: applicant[:id])
+    end
+    applicant.reload
+    assert_not applicant.rejected?
+  end
+
+  test "can approve an already-rejected applicant" do
+    applicant = applicants(:rejected)
+
+    assert applicant.rejected?
+    post admin_applicant_approve_path(id: applicant[:id])
+    applicant.reload
+    assert applicant.approved?
+  end
+end

--- a/test/controllers/admin/applicants_controller_test.rb
+++ b/test/controllers/admin/applicants_controller_test.rb
@@ -55,4 +55,13 @@ class Admin::ApplicantsControllerTest < ActionDispatch::IntegrationTest
     applicant.reload
     assert applicant.approved?
   end
+
+  test "can identify the reviewer" do
+    admin = users(:admin)
+    applicant = applicants(:confirmed)
+
+    post admin_applicant_approve_path(id: applicant[:id])
+    applicant.reload
+    assert_equal admin, applicant.reviewer
+  end
 end

--- a/test/models/applicant_test.rb
+++ b/test/models/applicant_test.rb
@@ -177,4 +177,16 @@ class ApplicantTest < ActiveSupport::TestCase
     assert_equal review_note, confirmed_applicant.review_note
     assert_equal review_note, confirmed_applicant.review_note_internal
   end
+
+  test "can associate a reviewer" do
+    admin = users(:admin)
+    confirmed_applicant = applicants(:confirmed)
+
+    confirmed_applicant.approve(
+      reviewer: admin
+    )
+    confirmed_applicant.reload
+
+    assert_equal admin, confirmed_applicant.reviewer
+  end
 end


### PR DESCRIPTION
This PR adds an applicant management page to the admin area that lets admins review new applicants and look at old applicants.

**Testing:**
- `rails db:migrate`
- Fill in some `NULL` values in the `applicants` table with this Rails console command: `Applicant.reviewed.update_all(reviewed_at: Time.now, reviewer_id: User.with_role(:admin).first.id)`
- `./bin/dev` and also run Sidekiq (to send emails)
- While logged out, go to the Request Access page and request access using an email address you can receive email at (and that doesn't already have an account) and then confirm that email address from your inbox.
- Now, log in as an admin and go to the `/admin/applicants` page
- ✅ You should see your application! Decide that you're worthy and click the Approve button.
- ✅ You should receive an email (to the address you requested access with) telling you that you've been approved and prompting you to create a password.
- Do this again, but this time reject the application.
- Note that the "Reviewed applicants" table correctly shows the details and review status of the applicants.

Closes #273