### PR TITLE
Fix ability for users to download Insights data

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,7 +81,7 @@ class User < ApplicationRecord
   def assign_default_roles
     if self.roles.blank?
       self.add_role :new_user
-      self.add_role :insights_user
+      self.add_role :fact_check_insights_user
     end
   end
 

--- a/db/migrate/20221104200350_change_insights_user_role.rb
+++ b/db/migrate/20221104200350_change_insights_user_role.rb
@@ -1,0 +1,10 @@
+class ChangeInsightsUserRole < ActiveRecord::Migration[7.0]
+  def up
+    # See https://github.com/TechAndCheck/zenodotus/issues/433
+    Role.where(name: "insights_user").update(name: "fact_check_insights_user")
+  end
+
+  def down
+    Role.where(name: "fact_check_insights_user").update(name: "insights_user")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_04_070857) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_04_200350) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,7 +23,7 @@ AwsS3Downloader.singleton_class.prepend(S3OverRide)
 
 Role.create!([
   { name: "new_user" },
-  { name: "insights_user" },
+  { name: "fact_check_insights_user" },
   { name: "media_vault_user" },
   { name: "admin" },
 ])
@@ -114,16 +114,16 @@ Applicant.create!([
 ])
 
 # Create the standard Insights user (has completed setup and signed in)
-insights_user = User.create_from_applicant(Applicant.find_by(email: "insights@example.com"))
-insights_user.update!({
+fact_check_insights_user = User.create_from_applicant(Applicant.find_by(email: "insights@example.com"))
+fact_check_insights_user.update!({
   # Override the randomized initial password.
   password: easy_password,
   password_confirmation: easy_password,
 })
 
 # Create the standard Vault user (has completed setup and signed in)
-vault_user = User.create_from_applicant(Applicant.find_by(email: "vault@example.com"))
-vault_user.update!({
+media_vault_user = User.create_from_applicant(Applicant.find_by(email: "vault@example.com"))
+media_vault_user.update!({
   # Override the randomized initial password.
   password: easy_password,
   password_confirmation: easy_password,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ Zenodotus' `User` model handles authentication for the app via [Devise](https://
 Roles:
 
 - `new_user`: Indicates a user was newly-created and has not yet gone through the setup process (clicked the link in their welcome email and chosen their own password). Applied to every new user created from an applicant, and removed when they have completed their own setup process.
-- `insights_user`: Indicates a user has access to Fact-Check Insights. Applied to every new user created from an applicant.
+- `fact_check_insights_user`: Indicates a user has access to Fact-Check Insights. Applied to every new user created from an applicant.
 - `media_vault_user`: Indicates a user has access to MediaVault. Currently only applied manually.
 - `admin`: Indicates a user is authorized to administrate the site. (I.e., an internal user.)
 

--- a/test/controllers/fact_check_insights_controller_test.rb
+++ b/test/controllers/fact_check_insights_controller_test.rb
@@ -115,7 +115,7 @@ class FactCheckInsightsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "can download data as a permitted user" do
-    sign_in users(:insights_user)
+    sign_in users(:fact_check_insights_user)
 
     get fact_check_insights_download_path(format: :json)
     assert_response :success

--- a/test/controllers/media_vault_controller_test.rb
+++ b/test/controllers/media_vault_controller_test.rb
@@ -8,7 +8,7 @@ class MediaVaultControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should not allow Insights-only users to view dashboard" do
-    sign_in users(:insights_user)
+    sign_in users(:fact_check_insights_user)
 
     get media_vault_dashboard_url
 

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -3,8 +3,8 @@
 new_user:
   name: :new_user
 
-insights_user:
-  name: :insights_user
+fact_check_insights_user:
+  name: :fact_check_insights_user
 
 media_vault_user:
   name: :media_vault_user

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -16,7 +16,7 @@ user:
   encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
   confirmed_at: <%= Time.now %>
   roles:
-    - insights_user
+    - fact_check_insights_user
     - media_vault_user
 
 new_user:
@@ -26,15 +26,15 @@ new_user:
   confirmed_at: <%= Time.now %>
   roles:
     - new_user
-    - insights_user
+    - fact_check_insights_user
 
-insights_user:
+fact_check_insights_user:
   name: "Insights User's Name"
   email: "insights-only-user@example.com"
   encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
   confirmed_at: <%= Time.now %>
   roles:
-    - insights_user
+    - fact_check_insights_user
 
 media_vault_user:
   name: "Vault User's Name"
@@ -42,7 +42,7 @@ media_vault_user:
   encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
   confirmed_at: <%= Time.now %>
   roles:
-    - insights_user
+    - fact_check_insights_user
     - media_vault_user
 
 admin:

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -7,7 +7,7 @@ class UserTest < ActiveSupport::TestCase
     user = User.create_from_applicant(approved_applicant)
 
     assert user.is_new_user?
-    assert user.is_insights_user?
+    assert user.is_fact_check_insights_user?
   end
 
   test "should assign Vault applicants the Vault role" do
@@ -19,16 +19,16 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "should recognize Insights-only users" do
-    insights_user = users(:insights_user)
+    fact_check_insights_user = users(:fact_check_insights_user)
 
-    assert insights_user.is_insights_user?
-    assert_not insights_user.is_media_vault_user?
+    assert fact_check_insights_user.is_fact_check_insights_user?
+    assert_not fact_check_insights_user.is_media_vault_user?
   end
 
   test "should recognize MediaVault users" do
     media_vault_user = users(:media_vault_user)
 
-    assert media_vault_user.is_insights_user?
+    assert media_vault_user.is_fact_check_insights_user?
     assert media_vault_user.is_media_vault_user?
   end
 
@@ -111,7 +111,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "cannot send setup email to previously logged-in user" do
-    user = users(:insights_user)
+    user = users(:fact_check_insights_user)
 
     assert_raises User::AlreadySetupError do
       user.send_setup_instructions


### PR DESCRIPTION
lol.

This PR lets non-admin Insights users download Insights data. The problem is described in the attached issue, but the chosen solution is actually to rename one of our Rolify roles. Consequently, while the seeds have been updated, this PR does add a migration to convert your existing roles without having to reset the database. But **don't run the migration right away**! See testing instructions below.

**Testing:**
1. On `master`, log in as `insights@example.com` (or any other Insights-permitted **non-admin** user)
2. Go to the download page and try to download data
3. ❌ You should receive a 401 unauthorized response
4. Switch to this branch `433-fix-insights-user-role`
5. `rails db:migrate`
6. Repeat the steps above
7. ✅ You should be able to download the data

I also added new tests, so `rails t` should run clean.

Closes #433 