### PR TITLE
Only allow admins to use archive URL function

### DIFF
--- a/app/controllers/media_vault/archive_controller.rb
+++ b/app/controllers/media_vault/archive_controller.rb
@@ -1,6 +1,11 @@
 # typed: strict
 
 class MediaVault::ArchiveController < MediaVaultController
+  before_action :authenticate_super_user!, only: [
+    :add,
+    :submit_url,
+  ]
+
   skip_before_action :authenticate_user!, only: :scrape_result_callback
   skip_before_action :must_be_media_vault_user, only: :scrape_result_callback
 

--- a/app/views/layouts/media_vault/_header.html.erb
+++ b/app/views/layouts/media_vault/_header.html.erb
@@ -22,7 +22,9 @@
 					<li><%= link_to media_vault_guide_path, class: "btn btn--naked" do %><span>Guide<span class="hideable"> to MediaVault</span></span><% end %></li>
 					<li><%= link_to media_vault_text_search_path, class: "btn btn--naked" do %><span>Text Search</span><% end %></li>
 					<li><%= link_to media_vault_image_search_path, class: "btn btn--naked" do %><span>Media Search</span><% end %></li>
-					<li><%= link_to media_vault_archive_add_path, class: "btn" do %><span>Add URL</span><% end %></li>
+					<% if user_signed_in? && current_user.is_admin? %>
+						<li><%= link_to media_vault_archive_add_path, class: "btn" do %><span>Add URL</span><% end %></li>
+					<% end %>
 				<% else %>
 					<li>(Request Access TBD)</li>
 				<% end %>


### PR DESCRIPTION
This PR hides the Add URL navbar item from non-admins, and locks down the routes so that only admins can access them.

**Testing:**
- Log in as `vault@example.com` (or whatever your local Vault-permitted, **non-admin** user is)
- ✅ Note that there is no "Add URL" item in the navbar
- ✅ Try to go to `/archive/add` and get booted back to the home page with a no-no message
- Log in as `admin@example.com` (or any other admin)
- ✅ Note that there is an "Add URL" item in the navbar
- ✅ Click it and/or go to `/archive/add` and make sure you get the form
- You can also attempt to archive a URL (which should work as an admin) but that depends on the rest of your rig being set up for scraping correctly and should work as before anyway.

Closes #441