### PR TITLE
Add ersatz Request Access to MediaVault flow for Insights users

### DIFF
--- a/app/views/layouts/media_vault/_header.html.erb
+++ b/app/views/layouts/media_vault/_header.html.erb
@@ -26,7 +26,7 @@
 						<li><%= link_to media_vault_archive_add_path, class: "btn" do %><span>Add URL</span><% end %></li>
 					<% end %>
 				<% else %>
-					<li>(Request Access TBD)</li>
+					<li><%= render partial: "media_vault/request_access_instructions" %></li>
 				<% end %>
 			</ol>
 		<% end %>

--- a/app/views/media_vault/_request_access_instructions.html.erb
+++ b/app/views/media_vault/_request_access_instructions.html.erb
@@ -1,0 +1,9 @@
+<%= mail_to "hello@factcheckinsights.org", {
+	class: "btn #{button_class if defined?(button_class)}",
+	subject: "Request access to MediaVault by Fact-Check Insights user",
+	body: "I would like to request that my account, #{current_user.email}, be granted access to use MediaVault.
+
+Reason for request:"
+} do %>
+	<span>Request access</span>
+<% end %>

--- a/app/views/media_vault/index.html.erb
+++ b/app/views/media_vault/index.html.erb
@@ -6,7 +6,17 @@
 		<p>Our cutting-edge system gathers manipulated images and videos shared around the world that have been analyzed by reputable fact-checking organizations. The MediaVault archive allows fact-checkers to maintain a vital portion of their work, and enables quicker research and identification of patterns used in misleading social media posts.</p>
 		<p>MediaVault is free for use by fact-checkers, journalists and others working to debunk misinformation shared online, but registration is required.</p>
 		<div class="btn-container">
-			<%= link_to "Request Access", new_applicant_path, class: "btn btn--reversed btn--lg" %>
+			<% if user_signed_in? %>
+				<% if current_user.can_access_media_vault? %>
+					<%= link_to "Go to the Dashboard", media_vault_dashboard_path, class: "btn btn--reversed btn--lg" %>
+				<% else %>
+					<%= render partial: "media_vault/request_access_instructions", locals: { button_class: "btn--lg" } %>
+				<% end %>
+			<% else %>
+				<%= link_to "Request Access", new_applicant_path, class: "btn btn--lg" %>
+				<span class="mx-2">or</span>
+				<%= link_to "Log In", new_user_session_path, class: "btn btn--reversed btn--lg" %>
+			<% end %>
 		</div>
 	</div>
 	<div class="hidden lg:block lg:basis-2/4">


### PR DESCRIPTION
In #382, we describe the need for Insights users without Vault access to request Vault access through a more streamlined flow than filling out the entire Request Access form (which would fail as-is anyway, since they already have an account), and allowing admins the ability to grant existing accounts Vault access.

Until we implement that, this PR adds a stand-in process: when an Insights user is logged in and goes to Vault, the Request Access link spawns an email that lets them request access from the admins. It does nothing on the back end at all; an admin currently would have to then ask a developer to grant the access using the console.

While not ideal, this at least gives users _some_ path to express interest, and us a path to collect interest (and take action).

This PR also modifies the Vault home page based on authentication/permission status, rather than always showing the "Request Access" button.

**Testing:**
- Go to the vault as an unauthenticated user
- ✅ Note that the home page shows "**Request access** or **Log in**" buttons that go to their respective functions
- Log in to Vault as an admin or a Vault-permitted user
- ✅ Note that the home page (not Dashboard, but actual root) shows a "Go to the Dashboard button"
- Log in as an Insights-only (non-Vault, non-admin) user
- ✅ Note that the home page and the header have a "Request access" button and that clicking it spawns a new email that looks like the below:
   <img width="588" alt="image" src="https://user-images.githubusercontent.com/4731/200432137-a4bd9ea3-e999-4e33-a096-288fe22b7c04.png">

Affects #382 (but does not close it)
