### PR TITLE
Rename ingest endpoint

### DIFF
--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -1,5 +1,5 @@
 class ClaimReview < ApplicationRecord
-  validates :media_review_id, presence: true
+  # validates :media_review_id, presence: true
   belongs_to :media_review, optional: true, class_name: "MediaReview"
 
   # CSV export formatting

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,7 @@ Rails.application.routes.draw do
   # but should still be scoped by `media_vault` module.
   scope module: "media_vault", as: "media_vault" do
     scope "ingest", as: "ingest" do
-      post "submit_media_review", to: "ingest#submit_review", as: "api_raw"
+      post "submit_review", to: "ingest#submit_review", as: "api_raw"
       post "submit_media_review_source", to: "ingest#submit_media_review_source", as: "api_url"
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,7 @@ Rails.application.routes.draw do
   # but should still be scoped by `media_vault` module.
   scope module: "media_vault", as: "media_vault" do
     scope "ingest", as: "ingest" do
-      post "submit_media_review", to: "ingest#submit_media_review", as: "api_raw"
+      post "submit_media_review", to: "ingest#submit_review", as: "api_raw"
       post "submit_media_review_source", to: "ingest#submit_media_review_source", as: "api_url"
     end
 

--- a/db/migrate/20221108194425_remove_null_contraint_from_claim_review_for_media_review.rb
+++ b/db/migrate/20221108194425_remove_null_contraint_from_claim_review_for_media_review.rb
@@ -1,0 +1,5 @@
+class RemoveNullContraintFromClaimReviewForMediaReview < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :claim_reviews, :media_review_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_04_200350) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_08_194425) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -83,7 +83,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_04_200350) do
     t.datetime "date_published"
     t.jsonb "item_reviewed"
     t.jsonb "review_rating"
-    t.uuid "media_review_id", null: false
+    t.uuid "media_review_id"
     t.index ["media_review_id"], name: "index_claim_reviews_on_media_review_id"
   end
 

--- a/public/json-schemas/claim-review-schema.json
+++ b/public/json-schemas/claim-review-schema.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$ref": "#/definitions/claimReview",
+  "definitions": {
+    "claimReview": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "@context": {
+          "type": "string"
+        },
+        "@type": {
+          "type": "string"
+        },
+        "datePublished": {
+          "type": "string",
+          "format": "date"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "qt-uri-protocols": [
+            "https"
+          ]
+        },
+        "author": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/person"
+            },
+            {
+              "$ref": "#/definitions/organization"
+            }
+          ]
+        },
+        "claimReviewed": {
+          "type": "string"
+        },
+        "reviewRating": {
+          "$ref": "#/definitions/reviewRating"
+        },
+        "itemReviewed": {
+          "$ref": "#/definitions/claimReviewItemReviewed"
+        }
+      }
+    },
+    "person": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "@type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "jobTitle": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "sameAs": {
+          "type": "array"
+        }
+      },
+      "required": [
+        "@type",
+        "name"
+      ],
+      "title": "Person"
+    },
+    "organization": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "@type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string",
+          "format": "uri",
+          "qt-uri-protocols": [
+            "https"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "qt-uri-protocols": [
+            "https"
+          ]
+        }
+      },
+      "required": [
+        "@type",
+        "url"
+      ],
+      "title": "Organization"
+    },
+    "reviewRating": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "@type": {
+          "type": "string"
+        },
+        "ratingValue": {
+          "type": "string"
+        },
+        "bestRating": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string",
+          "format": "uri",
+          "qt-uri-protocols": [
+            "https"
+          ]
+        },
+        "alternateName": {
+          "type": "string"
+        },
+        "ratingExplanation": {
+          "type": "string"
+        },
+        "worstRating": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "@type",
+        "alternateName"
+      ],
+      "title": "ReviewRating"
+    },
+    "claimReviewItemReviewed": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "@type": {
+          "type": "string"
+        },
+        "author": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/person"
+            },
+            {
+              "$ref": "#/definitions/organization"
+            }
+          ]
+        },
+        "appearance": {
+          "type": "array"
+        },
+        "datePublished": {
+          "type": "string",
+          "format": "date"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "@type"
+      ],
+      "title": "MediaReviewItemReviewed"
+    }
+  }
+}


### PR DESCRIPTION
This renames the ingestion endpoint and allow ClaimReview or MediaReview to be submitted. It adds schema validation for ClaimReview and also removes a `media_review_id` null constraint that was on the ClaimReview model. Otherwise there should be no changed functionality.

To test:
`rails db:migrate`
`rails t`

closes  #446