### PR TITLE
Enable updates to `MediaReview`/`ClaimReview`

### DIFF
--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -31,6 +31,32 @@ class ClaimReview < ApplicationRecord
     item_reviewed "itemReviewed_author_sameAs" do |item_reviewed| item_reviewed.dig("author", "sameAs") end
   end
 
+  sig { params(claim_review_hash: Hash, external_unique_id: T.nilable(String), should_update: T::Boolean).returns(ClaimReview) }
+  def self.create_or_update_from_claim_review_hash(claim_review_hash, external_unique_id, should_update)
+    if should_update
+      existing_claim_review = ClaimReview.where(external_unique_id: external_unique_id).first
+      existing_claim_review.update!(
+        date_published: claim_review_hash["datePublished"],
+        url: claim_review_hash["url"],
+        author: claim_review_hash["author"],
+        claim_reviewed: claim_review_hash["claimReviewed"],
+        review_rating: claim_review_hash["reviewRating"],
+        item_reviewed: claim_review_hash["itemReviewed"],
+      )
+      existing_claim_review.reload
+    else
+      ClaimReview.create!(
+        external_unique_id: external_unique_id,
+        date_published: claim_review_hash["datePublished"],
+        url: claim_review_hash["url"],
+        author: claim_review_hash["author"],
+        claim_reviewed: claim_review_hash["claimReviewed"],
+        review_rating: claim_review_hash["reviewRating"],
+        item_reviewed: claim_review_hash["itemReviewed"],
+      )
+    end
+  end
+
   sig { returns(String) }
   def render_for_export
     ClaimReviewBlueprint.render(self)

--- a/db/migrate/20221109152113_add_external_unique_id_to_claim_review_and_media_review.rb
+++ b/db/migrate/20221109152113_add_external_unique_id_to_claim_review_and_media_review.rb
@@ -1,0 +1,6 @@
+class AddExternalUniqueIdToClaimReviewAndMediaReview < ActiveRecord::Migration[7.0]
+  def change
+    add_column :claim_reviews, :external_unique_id, :uuid, index: true
+    add_column :media_reviews, :external_unique_id, :uuid, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_08_194425) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_09_152113) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_08_194425) do
     t.jsonb "item_reviewed"
     t.jsonb "review_rating"
     t.uuid "media_review_id"
+    t.uuid "external_unique_id"
     t.index ["media_review_id"], name: "index_claim_reviews_on_media_review_id"
   end
 
@@ -204,6 +205,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_08_194425) do
     t.jsonb "item_reviewed"
     t.text "url"
     t.jsonb "media_item_appearance"
+    t.uuid "external_unique_id"
     t.index ["archive_item_id"], name: "index_media_reviews_on_archive_item_id"
   end
 


### PR DESCRIPTION
In tandem with [FactStream PR] this PR lets us update `ClaimReview` and `MediaReview` records when we receive revisions to them from `FactStream`. 

We recognize those revisions by storing the new `external_unique_id` attribute `FactStream` attaches to `ClaimReview` and `MediaReview` and using it to see whether we've already stored identically id'd objects. 

# Testing instructions
1. `rails db migrate` (add indexed `external_unique_id` column to `ClaimReview` and `MediaReview`)
2. `rake`

Closes #449