### PR TITLE
Log user in after changing password

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -96,7 +96,11 @@ class AccountsController < ApplicationController
   sig { void }
   def change_password
     typed_params = TypedParams[ChangePasswordParams].new.extract!(params)
+
     current_user.reset_password(typed_params.password, typed_params.confirmed_password)
+    # For some reason, despite having the settings correct, changing the password logs the user out
+    # This logs them straight back in
+    bypass_sign_in(current_user)
 
     respond_to do |format|
       if typed_params.password != typed_params.confirmed_password


### PR DESCRIPTION
For some reason changing the password resets the users session and logs them out. Now we just programatically log them back in immediately.

To test:

On master branch:
1. Log in with a user
2. Change the password
3. Refresh the page - you'll end up at the log in page

Switch to this branch:
1. Log in with user
2. Change the password
3. Refresh the page - you should stay on the same page

closes #355