### PR TITLE
Fix video searching

### DIFF
--- a/app/models/image_search.rb
+++ b/app/models/image_search.rb
@@ -62,7 +62,6 @@ class ImageSearch < ApplicationRecord
       images
     else
       # For videos we have to loop
-
       video_hashes = []
       self.dhashes.each do |dhash|
         video_hashes = video_hashes | Zelkova.graph.search(dhash["dhash"])
@@ -71,9 +70,13 @@ class ImageSearch < ApplicationRecord
       videos = video_hashes.map do |video_hash|
         hash = ImageHash.find(video_hash[:node].metadata[:id])
         { video: hash.archive_item, distance: video_hash[:distance] }
-      end.uniq
+      end
 
       videos.sort_by! { |video| video[:distance] }
+
+      # Videos are now sorted by distance, but we want to only keep the shortest distance
+      videos.uniq! { |video_hash| video_hash[:video] }
+
       videos
     end
   end

--- a/app/views/media_vault/image_search/_search_result_list_item_facebook_post.html.erb
+++ b/app/views/media_vault/image_search/_search_result_list_item_facebook_post.html.erb
@@ -14,7 +14,6 @@
 
 <div class="border rounded mb-5 flex flex-col md:flex-row p-6 md:h-48">
   <div class="flex-none h-96 mb-5 md:mb-0 md:h-auto md:w-32 overflow-hidden rounded">
-    <% debugger if result.nil? %>
     <a href="#"><img src="<%= preview_image_url %>" /></a>
   </div>
   <div class="overflow-hidden md:pl-5 mr-5 flex flex-col md:flex-row w-full text-left justify-around">

--- a/app/views/media_vault/image_search/_search_result_list_item_facebook_post.html.erb
+++ b/app/views/media_vault/image_search/_search_result_list_item_facebook_post.html.erb
@@ -1,6 +1,21 @@
+<%
+    if result.key?(:image)
+      result = result[:image]
+
+      return if result.archivable_item.images.count.zero?
+      preview_image_url = result.archivable_item.images.first.image_url
+    else
+      result = result[:video]
+
+      return if result.archivable_item.videos.count.zero?
+      preview_image_url = result.archivable_item.videos.first.video_derivatives[:preview].url
+    end
+%>
+
 <div class="border rounded mb-5 flex flex-col md:flex-row p-6 md:h-48">
   <div class="flex-none h-96 mb-5 md:mb-0 md:h-auto md:w-32 overflow-hidden rounded">
-    <a href="#"><img src="<%= result[:image].archivable_item.images.first.image_url %>" /></a>
+    <% debugger if result.nil? %>
+    <a href="#"><img src="<%= preview_image_url %>" /></a>
   </div>
   <div class="overflow-hidden md:pl-5 mr-5 flex flex-col md:flex-row w-full text-left justify-around">
     <div class="flex flex-col flex-wrap justify-around">
@@ -14,12 +29,12 @@
         <a href="#">Fact Check Link <i class="fas fa-external-link-square-alt"></i></a>
       </div>
       <div class="h-8">
-        Likes: <%= result[:image].facebook_post.number_of_likes %>
+        Likes: <%= result.facebook_post.number_of_likes %>
       </div>
     </div>
     <div class="flex flex-col flex-wrap justify-around">
       <div class="h-8">
-        Retrieved At: <%= result[:image].created_at.to_formatted_s(:long_ordinal) %>
+        Retrieved At: <%= result.created_at.to_formatted_s(:long_ordinal) %>
       </div>
       <div class="h-8">
         Media Review Rating: Manipulated
@@ -28,7 +43,7 @@
         Rating Organization: The Washington Post
       </div>
       <div class="h-8">
-        Fact Check Publish Date: <%= result[:image].facebook_post.posted_at.to_formatted_s(:long_ordinal) %>
+        Fact Check Publish Date: <%= result.facebook_post.posted_at.to_formatted_s(:long_ordinal) %>
       </div>
     </div>
     <div class="flex flex-col justify-between md:w-1/3">
@@ -43,10 +58,10 @@
   <div class="flex-none md:w-32 pl-5 border-t md:border-t-0 md:border-l mt-5 md:mt-0">
     <div class="flex flex-col items-center text-center justify-center">
       <a href="#">
-        <img src="<%= result[:image].facebook_post.author.profile_image.url %>" class="w-20 h-20 rounded-full inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
+        <img src="<%= result.facebook_post.author.profile_image.url %>" class="w-20 h-20 rounded-full inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
       </a>
-      <a href="#" class="font-medium title-font mt-1 text-gray-900 text-lg">@<%= result[:image].facebook_post.author.name %></a>
-      <a href="#"><p class="text-base"><%= result[:image].facebook_post.author.name %></p></a>
+      <a href="#" class="font-medium title-font mt-1 text-gray-900 text-lg">@<%= result.facebook_post.author.name %></a>
+      <a href="#"><p class="text-base"><%= result.facebook_post.author.name %></p></a>
     </div>
   </div>
 </div>

--- a/app/views/media_vault/image_search/_search_result_list_item_instagram_post.html.erb
+++ b/app/views/media_vault/image_search/_search_result_list_item_instagram_post.html.erb
@@ -1,6 +1,20 @@
+<%
+    if result.key?(:image)
+      result = result[:image]
+
+      return if result.archivable_item.images.count.zero?
+      preview_image_url = result.archivable_item.images.first.image_url
+    else
+      result = result[:video]
+
+      return if result.archivable_item.videos.count.zero?
+      preview_image_url = result.archivable_item.videos.first.video_derivatives[:preview].url
+    end
+%>
+
 <div class="border rounded mb-5 flex flex-col md:flex-row p-6 md:h-48">
   <div class="flex-none h-96 mb-5 md:mb-0 md:h-auto md:w-32 overflow-hidden rounded">
-    <a href="#"><img src="<%= result[:image].archivable_item.images.first.image_url %>" /></a>
+    <a href="#"><img src="<%= preview_image_url %>" /></a>
   </div>
   <div class="overflow-hidden md:pl-5 mr-5 flex flex-col md:flex-row w-full text-left justify-around">
     <div class="flex flex-col flex-wrap justify-around">
@@ -14,12 +28,12 @@
         <a href="#">Fact Check Link <i class="fas fa-external-link-square-alt"></i></a>
       </div>
       <div class="h-8">
-        Likes: <%= result[:image].instagram_post.number_of_likes %>
+        Likes: <%= result.instagram_post.number_of_likes %>
       </div>
     </div>
     <div class="flex flex-col flex-wrap justify-around">
       <div class="h-8">
-        Retrieved At: <%= result[:image].created_at.to_formatted_s(:long_ordinal) %>
+        Retrieved At: <%= result.created_at.to_formatted_s(:long_ordinal) %>
       </div>
       <div class="h-8">
         Media Review Rating: Manipulated
@@ -28,7 +42,7 @@
         Rating Organization: The Washington Post
       </div>
       <div class="h-8">
-        Fact Check Publish Date: <%= result[:image].instagram_post.posted_at.to_formatted_s(:long_ordinal) %>
+        Fact Check Publish Date: <%= result.instagram_post.posted_at.to_formatted_s(:long_ordinal) %>
       </div>
     </div>
     <div class="flex flex-col justify-between md:w-1/3">
@@ -43,10 +57,10 @@
   <div class="flex-none md:w-32 pl-5 border-t md:border-t-0 md:border-l mt-5 md:mt-0">
     <div class="flex flex-col items-center text-center justify-center">
       <a href="#">
-        <img src="<%= result[:image].instagram_post.author.profile_image_url %>" class="w-20 h-20 rounded-full inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
+        <img src="<%= result.instagram_post.author.profile_image_url %>" class="w-20 h-20 rounded-full inline-flex items-center justify-center bg-gray-200 text-gray-400"/>
       </a>
-      <a href="#" class="font-medium title-font mt-1 text-gray-900 text-lg">@<%= result[:image].instagram_post.author.handle %></a>
-      <a href="#"><p class="text-base"><%= result[:image].instagram_post.author.display_name %></p></a>
+      <a href="#" class="font-medium title-font mt-1 text-gray-900 text-lg">@<%= result.instagram_post.author.handle %></a>
+      <a href="#"><p class="text-base"><%= result.instagram_post.author.display_name %></p></a>
     </div>
   </div>
 </div>

--- a/config/initializers/zelkova.rb
+++ b/config/initializers/zelkova.rb
@@ -5,7 +5,7 @@ require "zelkova"
 Rails.configuration.after_initialize do
   # Build up the graph
   graph = Zelkova.graph
-  graph.radius = 100
+  graph.radius = 20
 
   ImageHash.all.each do |image_hash|
     graph.add_node(image_hash.dhash, { id: image_hash.id })


### PR DESCRIPTION
This dedups the search algorithm and returns the best matching frame. It then follows up with making Facebook and Instagram results properly manage videos vs images.

To test:
- Do a media search with something that's in the archive from either Facebook or instagram, then do the other (to guarantee that there's a result in the listing)
- That's about it, nothing will appear if there's an error because the JS throws a 500, if things do appear it works.

closes #459 