### PR TITLE
Fix some MediaVault-related styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,8 +30,7 @@
 @use "pages/fact_check_insights_download";
 @use "pages/fact_check_insights_guide";
 @use "pages/fact_check_insights_highlights";
-@use "pages/media_vault_home";
-@use "pages/media_vault_guide";
+@use "pages/media_vault";
 
 #site-wrapper {
 	display: flex;

--- a/app/assets/stylesheets/author_archives.scss
+++ b/app/assets/stylesheets/author_archives.scss
@@ -43,6 +43,7 @@ Doesn't include the author's profile info, which is assumed to be separate / a s
 .author-archive__title {
 	font-size: 1.5rem;
 	font-weight: shared.$font-weight--light;
+	margin-bottom: 0;
 }
 
 .author-archive__title__archive-size {

--- a/app/assets/stylesheets/pages/media_vault.scss
+++ b/app/assets/stylesheets/pages/media_vault.scss
@@ -1,0 +1,22 @@
+@use "shared";
+
+// Most of MediaVault should use a cleaner, sans-serif font.
+.site--media_vault {
+	font-family: shared.$font-family--sans-serif;
+	background-color: shared.$color--brand--fact-check-insights;
+}
+
+// But, certain pages (more reading-oriented ones) should use standard serif.
+#page--media_vault--home,
+#page--media_vault--guide,
+#page--media_vault--about,
+#page--media_vault--contact,
+#page--media_vault--optout,
+#page--media_vault--terms,
+#page--media_vault--privacy {
+	font-family: shared.$font-family--serif;
+}
+
+#page--media_vault--home {
+	background-color: shared.$color--brand--media-vault;
+}

--- a/app/assets/stylesheets/pages/media_vault_guide.scss
+++ b/app/assets/stylesheets/pages/media_vault_guide.scss
@@ -1,5 +1,0 @@
-@use "shared";
-
-#page--media_vault--guide {
-	background-color: shared.$color--brand--fact-check-insights;
-}

--- a/app/assets/stylesheets/pages/media_vault_home.scss
+++ b/app/assets/stylesheets/pages/media_vault_home.scss
@@ -1,5 +1,0 @@
-@use "shared";
-
-#page--media_vault--home {
-	background-color: shared.$color--brand--media-vault;
-}

--- a/app/views/media_vault/facebook_users/show.html.erb
+++ b/app/views/media_vault/facebook_users/show.html.erb
@@ -1,51 +1,53 @@
-<div class="author" data-controller="media-vault--author">
-  <img
-    class="author__image"
-    src="<%= @facebook_user.profile_image_url %>"
-    width="300" height="300"
-    alt="Profile photo of <%= @facebook_user.name %>"
-  >
-  <div class="author__profile">
-    <div class="author__name">
-      <span class="author__display-name"><%= @facebook_user.name %></span>
-    </div>
-    <div class="author__metadata">
-      <%= abbreviate_number(@facebook_user.followers_count) %>
-      <%= "follower".pluralize(@facebook_user.followers_count) %>
-      •
-      <%= abbreviate_number(@facebook_user.likes_count) %>
-      <%= "like".pluralize(@facebook_user.likes_count) %>
-    </div>
-    <div class="author__description">
-      <%= @facebook_user.profile %>
-    </div>
-  </div>
-</div>
+<div>
+	<div class="author" data-controller="media-vault--author">
+		<img
+			class="author__image"
+			src="<%= @facebook_user.profile_image_url %>"
+			width="300" height="300"
+			alt="Profile photo of <%= @facebook_user.name %>"
+		>
+		<div class="author__profile">
+			<div class="author__name">
+				<span class="author__display-name"><%= @facebook_user.name %></span>
+			</div>
+			<div class="author__metadata">
+				<%= abbreviate_number(@facebook_user.followers_count) %>
+				<%= "follower".pluralize(@facebook_user.followers_count) %>
+				•
+				<%= abbreviate_number(@facebook_user.likes_count) %>
+				<%= "like".pluralize(@facebook_user.likes_count) %>
+			</div>
+			<div class="author__description">
+				<%= @facebook_user.profile %>
+			</div>
+		</div>
+	</div>
 
-<div class="author-archive">
-  <div class="author-archive__header">
-    <h2 class="author-archive__title">
-      <span class="author-archive__title__archive-size"><%= @archive_items.length %></span>
-      <%= "item".pluralize(@archive_items.length) %>
-      archived
-    </h2>
-    <div class="author-archive__actions">
-      <%= link_to media_vault_facebook_user_path(@facebook_user, format: "json"), {
-        title: "Download user archive in JSON format",
-        class: "btn icon-prefixed",
-        download: true
-      } do %>
-        <%= use_svg "download-outline", svg_attrs: { class: "icon icon--lg", aria: { hidden: true } } %>
-        JSON
-      <% end %>
-    </div>
-  </div>
-  <div class="archive-items archive-items--masonry archive-items--boxed-items">
-    <% @archive_items.each do |archive_item| %>
-      <%= render partial: "media_vault/archive/archive_item", locals: {
-        **archive_item.normalized_attrs_for_views,
-        include_author: false
-      } %>
-    <% end %>
-  </div>
+	<div class="author-archive">
+		<div class="author-archive__header">
+			<h2 class="author-archive__title">
+				<span class="author-archive__title__archive-size"><%= @archive_items.length %></span>
+				<%= "item".pluralize(@archive_items.length) %>
+				archived
+			</h2>
+			<div class="author-archive__actions">
+				<%= link_to media_vault_facebook_user_path(@facebook_user, format: "json"), {
+					title: "Download user archive in JSON format",
+					class: "btn icon-prefixed",
+					download: true
+				} do %>
+					<%= use_svg "download-outline", svg_attrs: { class: "icon icon--lg", aria: { hidden: true } } %>
+					JSON
+				<% end %>
+			</div>
+		</div>
+		<div class="archive-items archive-items--masonry archive-items--boxed-items">
+			<% @archive_items.each do |archive_item| %>
+				<%= render partial: "media_vault/archive/archive_item", locals: {
+					**archive_item.normalized_attrs_for_views,
+					include_author: false
+				} %>
+			<% end %>
+		</div>
+	</div>
 </div>

--- a/app/views/media_vault/instagram_users/show.html.erb
+++ b/app/views/media_vault/instagram_users/show.html.erb
@@ -1,52 +1,54 @@
-<div class="author" data-controller="media-vault--author">
-  <img
-    class="author__image"
-    src="<%= @instagram_user.profile_image_url %>"
-    width="300" height="300"
-    alt="Profile photo of <%= @instagram_user.display_name %>"
-  >
-  <div class="author__profile">
-    <div class="author__name">
-      <span class="author__display-name"><%= @instagram_user.display_name %></span>
-      <span class="author__username">@<%= @instagram_user.handle %></span>
-    </div>
-    <div class="author__metadata">
-      <%= abbreviate_number(@instagram_user.followers_count) %>
-      <%= "follower".pluralize(@instagram_user.followers_count) %>
-      •
-      <%= abbreviate_number(@instagram_user.following_count) %>
-      following
-    </div>
-    <div class="author__description">
-      <%= @instagram_user.profile %>
-    </div>
-  </div>
-</div>
+<div>
+	<div class="author" data-controller="media-vault--author">
+		<img
+			class="author__image"
+			src="<%= @instagram_user.profile_image_url %>"
+			width="300" height="300"
+			alt="Profile photo of <%= @instagram_user.display_name %>"
+		>
+		<div class="author__profile">
+			<div class="author__name">
+				<span class="author__display-name"><%= @instagram_user.display_name %></span>
+				<span class="author__username">@<%= @instagram_user.handle %></span>
+			</div>
+			<div class="author__metadata">
+				<%= abbreviate_number(@instagram_user.followers_count) %>
+				<%= "follower".pluralize(@instagram_user.followers_count) %>
+				•
+				<%= abbreviate_number(@instagram_user.following_count) %>
+				following
+			</div>
+			<div class="author__description">
+				<%= @instagram_user.profile %>
+			</div>
+		</div>
+	</div>
 
-<div class="author-archive">
-  <div class="author-archive__header">
-    <h2 class="author-archive__title">
-      <span class="author-archive__title__archive-size"><%= @archive_items.length %></span>
-      <%= "item".pluralize(@archive_items.length) %>
-      archived
-    </h2>
-    <div class="author-archive__actions">
-      <%= link_to media_vault_instagram_user_path(@instagram_user, format: "json"), {
-        title: "Download user archive in JSON format",
-        class: "btn icon-prefixed",
-        download: true
-      } do %>
-        <%= use_svg "download-outline", svg_attrs: { class: "icon icon--lg", aria: { hidden: true } } %>
-        JSON
-      <% end %>
-    </div>
-  </div>
-  <div class="archive-items archive-items--masonry archive-items--boxed-items">
-    <% @archive_items.each do |archive_item| %>
-      <%= render partial: "media_vault/archive/archive_item", locals: {
-        **archive_item.normalized_attrs_for_views,
-        include_author: false
-      } %>
-    <% end %>
-  </div>
+	<div class="author-archive">
+		<div class="author-archive__header">
+			<h2 class="author-archive__title">
+				<span class="author-archive__title__archive-size"><%= @archive_items.length %></span>
+				<%= "item".pluralize(@archive_items.length) %>
+				archived
+			</h2>
+			<div class="author-archive__actions">
+				<%= link_to media_vault_instagram_user_path(@instagram_user, format: "json"), {
+					title: "Download user archive in JSON format",
+					class: "btn icon-prefixed",
+					download: true
+				} do %>
+					<%= use_svg "download-outline", svg_attrs: { class: "icon icon--lg", aria: { hidden: true } } %>
+					JSON
+				<% end %>
+			</div>
+		</div>
+		<div class="archive-items archive-items--masonry archive-items--boxed-items">
+			<% @archive_items.each do |archive_item| %>
+				<%= render partial: "media_vault/archive/archive_item", locals: {
+					**archive_item.normalized_attrs_for_views,
+					include_author: false
+				} %>
+			<% end %>
+		</div>
+	</div>
 </div>

--- a/app/views/media_vault/twitter_users/show.html.erb
+++ b/app/views/media_vault/twitter_users/show.html.erb
@@ -1,67 +1,69 @@
-<div class="author" data-controller="media-vault--author">
-  <img
-    class="author__image"
-    src="<%= @twitter_user.profile_image_url %>"
-    width="300" height="300"
-    alt="Profile photo of <%= @twitter_user.display_name %>"
-  >
-  <div class="author__profile">
-    <div class="author__name">
-      <span class="author__display-name"><%= @twitter_user.display_name %></span>
-      <span class="author__username">@<%= @twitter_user.handle %></span>
-    </div>
-    <div class="author__metadata">
-      <%= abbreviate_number(@twitter_user.followers_count) %>
-      <%= "follower".pluralize(@twitter_user.followers_count) %>
-      •
-      <%= abbreviate_number(@twitter_user.following_count) %>
-      following
-      •
-      <%= @twitter_user.location %>
-    </div>
-    <div class="author__description">
-      <%= @twitter_user.description %>
-    </div>
-    <div class="author__metadata">
-      <span class="icon-prefixed">
-        <%= use_svg "calendar-outline", svg_attrs: { class: "icon icon--xl", aria: { hidden: true } } %>
-        <span>
-          Joined Twitter on
-          <time
-            datetime="<%= @twitter_user.sign_up_date.iso8601 %>"
-            data-media-vault--author-target="timestamp"
-          >
-            <%= @twitter_user.sign_up_date %>
-          </time>
-        </span>
-    </div>
-  </div>
-</div>
+<div>
+	<div class="author" data-controller="media-vault--author">
+		<img
+			class="author__image"
+			src="<%= @twitter_user.profile_image_url %>"
+			width="300" height="300"
+			alt="Profile photo of <%= @twitter_user.display_name %>"
+		>
+		<div class="author__profile">
+			<div class="author__name">
+				<span class="author__display-name"><%= @twitter_user.display_name %></span>
+				<span class="author__username">@<%= @twitter_user.handle %></span>
+			</div>
+			<div class="author__metadata">
+				<%= abbreviate_number(@twitter_user.followers_count) %>
+				<%= "follower".pluralize(@twitter_user.followers_count) %>
+				•
+				<%= abbreviate_number(@twitter_user.following_count) %>
+				following
+				•
+				<%= @twitter_user.location %>
+			</div>
+			<div class="author__description">
+				<%= @twitter_user.description %>
+			</div>
+			<div class="author__metadata">
+				<span class="icon-prefixed">
+					<%= use_svg "calendar-outline", svg_attrs: { class: "icon icon--xl", aria: { hidden: true } } %>
+					<span>
+						Joined Twitter on
+						<time
+							datetime="<%= @twitter_user.sign_up_date.iso8601 %>"
+							data-media-vault--author-target="timestamp"
+						>
+							<%= @twitter_user.sign_up_date %>
+						</time>
+					</span>
+			</div>
+		</div>
+	</div>
 
-<div class="author-archive">
-  <div class="author-archive__header">
-    <h2 class="author-archive__title">
-      <span class="author-archive__title__archive-size"><%= @archive_items.length %></span>
-      <%= "item".pluralize(@archive_items.length) %>
-      archived
-    </h2>
-    <div class="author-archive__actions">
-      <%= link_to media_vault_twitter_user_path(@twitter_user, format: "json"), {
-        title: "Download user archive in JSON format",
-        class: "btn icon-prefixed",
-        download: true
-      } do %>
-        <%= use_svg "download-outline", svg_attrs: { class: "icon icon--lg", aria: { hidden: true } } %>
-        JSON
-      <% end %>
-    </div>
-  </div>
-  <div class="archive-items archive-items--masonry archive-items--boxed-items">
-    <% @archive_items.each do |archive_item| %>
-      <%= render partial: "media_vault/archive/archive_item", locals: {
-        **archive_item.normalized_attrs_for_views,
-        include_author: false
-      } %>
-    <% end %>
-  </div>
+	<div class="author-archive">
+		<div class="author-archive__header">
+			<h2 class="author-archive__title">
+				<span class="author-archive__title__archive-size"><%= @archive_items.length %></span>
+				<%= "item".pluralize(@archive_items.length) %>
+				archived
+			</h2>
+			<div class="author-archive__actions">
+				<%= link_to media_vault_twitter_user_path(@twitter_user, format: "json"), {
+					title: "Download user archive in JSON format",
+					class: "btn icon-prefixed",
+					download: true
+				} do %>
+					<%= use_svg "download-outline", svg_attrs: { class: "icon icon--lg", aria: { hidden: true } } %>
+					JSON
+				<% end %>
+			</div>
+		</div>
+		<div class="archive-items archive-items--masonry archive-items--boxed-items">
+			<% @archive_items.each do |archive_item| %>
+				<%= render partial: "media_vault/archive/archive_item", locals: {
+					**archive_item.normalized_attrs_for_views,
+					include_author: false
+				} %>
+			<% end %>
+		</div>
+	</div>
 </div>

--- a/app/views/media_vault/youtube_channels/show.html.erb
+++ b/app/views/media_vault/youtube_channels/show.html.erb
@@ -1,67 +1,69 @@
-<div class="author" data-controller="media-vault--author">
-  <img
-    class="author__image"
-    src="<%= @youtube_channel.channel_image_url %>"
-    width="300" height="300"
-    alt="Profile photo of <%= @youtube_channel.title %>"
-  >
-  <div class="author__profile">
-    <div class="author__name">
-      <span class="author__display-name"><%= @youtube_channel.title %></span>
-    </div>
-    <div class="author__metadata">
-      <%= abbreviate_number(@youtube_channel.num_subscribers) %>
-      <%= "subscriber".pluralize(@youtube_channel.num_subscribers) %>
-      •
-      <%= abbreviate_number(@youtube_channel.num_views) %>
-      <%= "view".pluralize(@youtube_channel.num_views) %>
-      •
-      <%= abbreviate_number(@youtube_channel.num_videos) %>
-      <%= "video".pluralize(@youtube_channel.num_videos) %>
-    </div>
-    <div class="author__description">
-      <%= @youtube_channel.description %>
-    </div>
-    <div class="author__metadata">
-      <span class="icon-prefixed">
-        <%= use_svg "calendar-outline", svg_attrs: { class: "icon icon--xl", aria: { hidden: true } } %>
-        <span>
-          Channel created on
-          <time
-            datetime="<%= @youtube_channel.sign_up_date.iso8601 %>"
-            data-media-vault--author-target="timestamp"
-          >
-            <%= @youtube_channel.sign_up_date %>
-          </time>
-        </span>
-    </div>
-  </div>
-</div>
+<div>
+	<div class="author" data-controller="media-vault--author">
+		<img
+			class="author__image"
+			src="<%= @youtube_channel.channel_image_url %>"
+			width="300" height="300"
+			alt="Profile photo of <%= @youtube_channel.title %>"
+		>
+		<div class="author__profile">
+			<div class="author__name">
+				<span class="author__display-name"><%= @youtube_channel.title %></span>
+			</div>
+			<div class="author__metadata">
+				<%= abbreviate_number(@youtube_channel.num_subscribers) %>
+				<%= "subscriber".pluralize(@youtube_channel.num_subscribers) %>
+				•
+				<%= abbreviate_number(@youtube_channel.num_views) %>
+				<%= "view".pluralize(@youtube_channel.num_views) %>
+				•
+				<%= abbreviate_number(@youtube_channel.num_videos) %>
+				<%= "video".pluralize(@youtube_channel.num_videos) %>
+			</div>
+			<div class="author__description">
+				<%= @youtube_channel.description %>
+			</div>
+			<div class="author__metadata">
+				<span class="icon-prefixed">
+					<%= use_svg "calendar-outline", svg_attrs: { class: "icon icon--xl", aria: { hidden: true } } %>
+					<span>
+						Channel created on
+						<time
+							datetime="<%= @youtube_channel.sign_up_date.iso8601 %>"
+							data-media-vault--author-target="timestamp"
+						>
+							<%= @youtube_channel.sign_up_date %>
+						</time>
+					</span>
+			</div>
+		</div>
+	</div>
 
-<div class="author-archive">
-  <div class="author-archive__header">
-    <h2 class="author-archive__title">
-      <span class="author-archive__title__archive-size"><%= @archive_items.length %></span>
-      <%= "item".pluralize(@archive_items.length) %>
-      archived
-    </h2>
-    <div class="author-archive__actions">
-      <%= link_to media_vault_youtube_channel_path(@youtube_channel, format: "json"), {
-        title: "Download channel archive in JSON format",
-        class: "btn icon-prefixed",
-        download: true
-      } do %>
-        <%= use_svg "download-outline", svg_attrs: { class: "icon icon--lg", aria: { hidden: true } } %>
-        JSON
-      <% end %>
-    </div>
-  </div>
-  <div class="archive-items archive-items--masonry archive-items--boxed-items">
-    <% @archive_items.each do |archive_item| %>
-      <%= render partial: "media_vault/archive/archive_item", locals: {
-        **archive_item.normalized_attrs_for_views,
-        include_author: false
-      } %>
-    <% end %>
-  </div>
+	<div class="author-archive">
+		<div class="author-archive__header">
+			<h2 class="author-archive__title">
+				<span class="author-archive__title__archive-size"><%= @archive_items.length %></span>
+				<%= "item".pluralize(@archive_items.length) %>
+				archived
+			</h2>
+			<div class="author-archive__actions">
+				<%= link_to media_vault_youtube_channel_path(@youtube_channel, format: "json"), {
+					title: "Download channel archive in JSON format",
+					class: "btn icon-prefixed",
+					download: true
+				} do %>
+					<%= use_svg "download-outline", svg_attrs: { class: "icon icon--lg", aria: { hidden: true } } %>
+					JSON
+				<% end %>
+			</div>
+		</div>
+		<div class="archive-items archive-items--masonry archive-items--boxed-items">
+			<% @archive_items.each do |archive_item| %>
+				<%= render partial: "media_vault/archive/archive_item", locals: {
+					**archive_item.normalized_attrs_for_views,
+					include_author: false
+				} %>
+			<% end %>
+		</div>
+	</div>
 </div>


### PR DESCRIPTION
This PR fixes a few things that had bugged me (or needed fixing) in MediaVault:

- Fixed the spacing between elements on author show pages (present since we started yielding page content directly into a grid wrapper in the application layout)
- Fixed spacing on the author archive title
- Defaulted all MediaVault pages to have creamy backgrounds (vs white) for more pleasant readability
- Defaulted all MediaVault pages to use a sans-serif typeface, with serif restored for very "designed" pages and long content pages

No issue, just odds and ends.