### PR TITLE
Paginate MediaVault dashboard

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @use "header";
 @use "icons";
 @use "images";
+@use "pagination";
 @use "search_box";
 @use "tables";
 @use "typography";

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -80,6 +80,15 @@ elements, but the examples will just use `<button>`.
 		--btn--padding--horizontal: 2em;
 	}
 
+	&.disabled {
+		--btn--color: gray;
+		--btn--background-color: transparent;
+		--btn--border-color: lightgray;
+		--btn--color--hover: gray;
+		--btn--background-color--hover: transparent;
+		--btn--border-color--hover: lightgray;
+	}
+
 	&.btn--reversed {
 		--btn--color: white;
 		--btn--background-color: #{shared.$color--dark};
@@ -124,6 +133,15 @@ elements, but the examples will just use `<button>`.
 
 	&.btn--naked {
 		--btn--border-color: transparent;
+
+		&.disabled {
+			--btn--color: gray;
+			--btn--background-color: transparent;
+			--btn--border-color: transparent;
+			--btn--color--hover: gray;
+			--btn--background-color--hover: transparent;
+			--btn--border-color--hover: transparent;
+		}
 
 		&.btn--danger {
 			--btn--color: #{shared.$color--mood--error};

--- a/app/assets/stylesheets/pagination.scss
+++ b/app/assets/stylesheets/pagination.scss
@@ -1,0 +1,52 @@
+/*
+Pagination
+
+Styling for the Pagy gem's pagination output.
+
+```html
+<nav class="pagy-nav pagination" aria-label="pager">
+	<span class="page prev"><a rel="prev" aria-label="previous">‹&nbsp;Prev</a></span>
+	<span class="page"><a>1</a></span>
+	<span class="page"><a rel="prev">2</a></span>
+	<span class="page active">3</span>
+	<span class="page"><a rel="next">4</a></span>
+	<span class="page"><a>5</a></span>
+	<span class="page gap">…</span>
+	<span class="page"><a>10</a></span>
+	<span class="page next"><a rel="next" aria-label="next">Next&nbsp;›</a></span>
+</nav>
+```
+*/
+@use "shared";
+@use "buttons";
+
+.pagination {
+	--pagination--external-spacing: clamp(2rem, 5vw, 4rem);
+	--pagination--internal-spacing: 0.25rem;
+
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: var(--pagination--internal-spacing);
+	margin-top: var(--pagination--external-spacing);;
+
+	.page {
+		> a {
+			@extend .btn;
+		}
+
+		&.disabled {
+			@extend .btn;
+
+			cursor: text;
+		}
+
+		&.active {
+			@extend .btn;
+			@extend .btn--reversed;
+
+			cursor: text;
+		}
+	}
+}

--- a/app/views/media_vault/archive/index.html.erb
+++ b/app/views/media_vault/archive/index.html.erb
@@ -2,9 +2,12 @@
 
 <%= turbo_frame_tag "modal" %>
 
-<div class="py-10 mx-auto" style="max-width:50rem;">
-  <h2 class="text-2xl mb-10">Most Recent Archived Media</h2>
-  <%= turbo_frame_tag "recent_archived_items", target: "_top", class: "archive-items" do %>
-    <% render partial: "archive_items", locals: { archive_items: @archive_items } %>
-  <% end %>
+<div class="content content--md content--center">
+	<%= turbo_frame_tag "archived_items", target: "_top", class: "archive-items" do %>
+		<% render partial: "archive_items", locals: { archive_items: @archive_items } %>
+	<% end %>
+
+	<%= turbo_frame_tag "archived_items_pagination", target: "_top" do %>
+		<%== pagy_nav(@pagy_archive_items) if @pagy_archive_items.pages > 1 %>
+	<% end %>
 </div>


### PR DESCRIPTION
This PR finally adds pagination to the MediaVault dashboard, locked to 50 items per page. It also adds generic pagination styling, applied to the generic Pagy markup and so automatically picked up by other places (like on the search history w/in user settings):

<img width="473" alt="Screenshot of pagination showing page 1 active and 29 pages available" src="https://user-images.githubusercontent.com/4731/202027679-82fed47d-d1da-4a64-a5d0-ead25c22060a.png">

**Testing:**
1. If you have fewer than 50 items in your local vault, then either add more (lol) or temporarily modify [`ARCHIVE_ITEMS_PER_PAGE`](https://github.com/TechAndCheck/zenodotus/blob/0c11eb4853c2fe42f7cf94b63e545598c77e06f4/app/controllers/media_vault/archive_controller.rb#L12) to be less than your archive size.
2. Load up the Dashboard and scroll to the bottom.
3. ✅ Pagination should appear and should be usable!

Note: This will be added to search results soon as they are further beautified in #364.

Closes #241 