### PR TITLE
Make Zeno S3 bucket configurable

### DIFF
--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -18,6 +18,7 @@ Figaro.require_keys("MAILGUN_API_KEY")
 
 if Figaro.env.USE_S3_DEV_TEST == "true" || Rails.env == "production"
   Figaro.require_keys("AWS_REGION")
+  Figaro.require_keys("AWS_S3_BUCKET_NAME")
   Figaro.require_keys("AWS_ACCESS_KEY_ID")
   Figaro.require_keys("AWS_SECRET_ACCESS_KEY")
 end

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -28,13 +28,14 @@ def make_shrine_cache
 end
 
 def make_shrine_storage
+  bucket_name = Figaro.env.AWS_S3_BUCKET_NAME
   case Rails.env
   when "development"
-    Figaro.env.USE_S3_DEV_TEST == "true" ? make_s3_bucket("zenodotus-testing") : Shrine::Storage::FileSystem.new("public", prefix: "uploads")
+    Figaro.env.USE_S3_DEV_TEST == "true" ? make_s3_bucket(bucket_name) : Shrine::Storage::FileSystem.new("public", prefix: "uploads")
   when "test"
-    Figaro.env.USE_S3_DEV_TEST == "true" ? make_s3_bucket("zenodotus-testing") : Shrine::Storage::Memory.new
+    Figaro.env.USE_S3_DEV_TEST == "true" ? make_s3_bucket(bucket_name) : Shrine::Storage::Memory.new
   when "production"
-    make_s3_bucket("zenodotus-production")
+    make_s3_bucket(bucket_name)
   end
 end
 


### PR DESCRIPTION
Realistically we only should use one of two S3 buckets for reading Zeno assets. That said, they should still be configurable as env vars rather than hard-coded.

This PR adds a requirement that you have the `AWS_S3_BUCKET_NAME` env var set (if you have S3 enabled), and uses it.

**Testing:**
1. Add the `AWS_S3_BUCKET_NAME` env var (set to `"zenodotus-testing"` locally)
2. `rails t` (make sure `USE_S3_DEV_TEST` is set to true during this test)
3. If you want to go further, import the SQL dump @cguess posted in Slack and make sure archived assets still work

Note: I've already added `AWS_S3_BUCKET_NAME` to staging on Heroku.

Related to issue #205