### PR TITLE
Add new ClaimReview attributes

### DIFF
--- a/app/blueprints/claim_review_blueprint.rb
+++ b/app/blueprints/claim_review_blueprint.rb
@@ -32,6 +32,8 @@ class ClaimReviewBlueprint < Blueprinter::Base
       "@type": claim_review.review_rating.dig("@type"),
       "ratingValue": claim_review.review_rating.dig("ratingValue"),
       "bestRating": claim_review.review_rating.dig("bestRating"),
+      "worstRating": claim_review.review_rating.dig("worstRating"),
+      "ratingExplanation": claim_review.review_rating.dig("ratingExplanation"),
       "image": claim_review.review_rating.dig("image"),
       "alternateName": claim_review.review_rating.dig("alternateName"),
     }
@@ -42,6 +44,8 @@ class ClaimReviewBlueprint < Blueprinter::Base
       "@type": claim_review.item_reviewed.dig("@type"),
       "datePublished": claim_review.item_reviewed.dig("datePublished"),
       "name": claim_review.item_reviewed.dig("name"),
+      "appearance": claim_review.item_reviewed.dig("appearance"),
+      "firstAppearance": claim_review.item_reviewed.dig("appearance", 0),
       "author": {
         "@type": claim_review.item_reviewed.dig("author", "@type"),
         "name": claim_review.item_reviewed.dig("author", "name"),

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -17,10 +17,14 @@ class ClaimReview < ApplicationRecord
 
     review_rating "reviewRating_@type" do |review_rating| review_rating["@type"] end
     review_rating "reviewRating_ratingValue" do |review_rating| review_rating["ratingValue"] end
+    review_rating "reviewRating_ratingExplanation" do |review_rating| review_rating["ratingExplanation"] end
     review_rating "reviewRating_bestRating" do |review_rating| review_rating["bestRating"] end
+    review_rating "reviewRating_worstRating" do |review_rating| review_rating["worstRating"] end
     review_rating "reviewRating_image" do |review_rating| review_rating["image"] end
     review_rating "reviewRating_alternateName" do |review_rating| review_rating["alternateName"] end
 
+    item_reviewed "itemReviewed_firstAppearance_@type" do |item_reviewed| item_reviewed.dig("appearance", 0, "@type") end
+    item_reviewed "itemReviewed_firstAppearance_url" do |item_reviewed| item_reviewed.dig("appearance", 0, "url") end
     item_reviewed "itemReviewed_@type" do |item_reviewed| item_reviewed["@type"] end
     item_reviewed "itemReviewed_datePublished" do |item_reviewed| item_reviewed["datePublished"] end
     item_reviewed "itemReviewed_name" do |item_reviewed| item_reviewed["name"] end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -272,11 +272,19 @@ ClaimReview.create(
       "jobTitle": "On the internet",
       "name": "Viral image"
     },
+    "appearance": [
+      {
+        "@type": "CreativeWork",
+        "url": "https://foobar.com/13531"
+      }
+    ]
   },
   review_rating: {
     "@type": "Rating",
     "ratingValue": "4",
     "bestRating": "5",
+    "worstRating": "0",
+    "ratingExplanation": "Don't worry about it",
     "image": "https://static.politifact.com/politifact/rulings/meter-false.jpg",
     "alternateName": "False"
   },

--- a/test/controllers/fact_check_insights_controller_test.rb
+++ b/test/controllers/fact_check_insights_controller_test.rb
@@ -72,11 +72,19 @@ class FactCheckInsightsControllerTest < ActionDispatch::IntegrationTest
           "jobTitle": "On the internet",
           "name": "Viral image"
         },
+        "appearance": [
+          {
+            "@type": "CreativeWork",
+            "url": "https://foobar.com/13531"
+          }
+        ]
       },
       review_rating: {
         "@type": "Rating",
         "ratingValue": "4",
         "bestRating": "5",
+        "worstRating": "0",
+        "ratingDescription": "Don't worry about it",
         "image": "https://static.politifact.com/politifact/rulings/meter-false.jpg",
         "alternateName": "False"
       },

--- a/test/models/claim_review_test.rb
+++ b/test/models/claim_review_test.rb
@@ -57,12 +57,16 @@ class ClaimReviewTest < ActiveSupport::TestCase
         "@type" => "Rating",
         "alternateName" => "False",
         "bestRating" => "9",
+        "worstRating" => nil,
+        "ratingExplanation" => nil,
         "ratingValue" => "4",
         "image" => nil,
       },
       "itemReviewed" => {
         "@type" => "Claim",
         "name" => "Claim name",
+        "appearance" => nil,
+        "firstAppearance" => nil,
         "author" => {
           "@type" => "Person",
           "jobTitle" => "On the internet",


### PR DESCRIPTION
This PR adds new sub-attributes to the `ClaimReview` model. One of these attributes, `ClaimReview.itemReviewed.appearance` is an array, so following our prior pattern, we only use its first value when exporting FactCheckInsights data to CSV. 

Closes #467 