### PR TITLE
Display archive items on Dashboard in boxes

### DIFF
--- a/app/views/media_vault/archive/index.html.erb
+++ b/app/views/media_vault/archive/index.html.erb
@@ -3,7 +3,7 @@
 <%= turbo_frame_tag "modal" %>
 
 <div class="content content--md content--center">
-	<%= turbo_frame_tag "archived_items", target: "_top", class: "archive-items" do %>
+	<%= turbo_frame_tag "archived_items", target: "_top", class: "archive-items archive-items--boxed-items" do %>
 		<% render partial: "archive_items", locals: { archive_items: @archive_items } %>
 	<% end %>
 


### PR DESCRIPTION
This PR wraps the Dashboard items in white boxes, just like they appear elsewhere.

**Before:**
![dashboard-before](https://user-images.githubusercontent.com/4731/202247868-9bc8ffc4-8021-411a-a42d-92dc3a2af634.jpeg)

**After:**
![dashboard-after](https://user-images.githubusercontent.com/4731/202247853-6abcdc45-e02d-4bb6-ba6c-594ed06182f8.jpeg)

Closes #472