### PR TITLE
Fix expand/collapse caption JS

### DIFF
--- a/app/assets/stylesheets/archive_items.scss
+++ b/app/assets/stylesheets/archive_items.scss
@@ -20,7 +20,7 @@ just to examine the template files unless/until we capture it better here.
 	<div
 		class="archive-item [archive-item--boxed]"
 		data-publishing-platform="{twitter|facebook|youtube|instagram|…}"
-		data-archive-caption-collapse-mode-value="{static|collapsed|expanded}"
+		data-media-vault--archive-caption-collapse-mode-value="{static|collapsed|expanded}"
 	>
 		<div class="archive-item__inner">
 			<a class="author">
@@ -152,7 +152,7 @@ may never be widely adopted. If you're reading this in a future when it's been a
 	font-weight: shared.$font-weight--normal;
 }
 
-.archive-item[data-archive-caption-collapse-mode-value="collapsed"] .archive-item__body-caption-content {
+.archive-item[data-media-vault--archive-caption-collapse-mode-value="collapsed"] .archive-item__body-caption-content {
 	--collapsed-lines-of-text: 3;
 
 	overflow: hidden;
@@ -166,7 +166,7 @@ may never be widely adopted. If you're reading this in a future when it's been a
 }
 
 @supports (-webkit-line-clamp: 2) {
-	.archive-item[data-archive-caption-collapse-mode-value="collapsed"] .archive-item__body-caption-content {
+	.archive-item[data-media-vault--archive-caption-collapse-mode-value="collapsed"] .archive-item__body-caption-content {
 		display: -webkit-box;
 		-webkit-line-clamp: var(--collapsed-lines-of-text);
 		-webkit-box-orient: vertical;

--- a/app/javascript/controllers/media_vault/archive_controller.js
+++ b/app/javascript/controllers/media_vault/archive_controller.js
@@ -27,7 +27,7 @@ export default class extends Controller {
       default:
         // This doesn't break anything for users, but we developers would want to know.
         // eslint-disable-next-line no-console
-        console.error('archive#toggleCaption called unexpectedly.')
+        console.error('media-vault--archive#toggleCaption called unexpectedly.')
     }
   }
 }

--- a/app/views/media_vault/media/_archive_item.html.erb
+++ b/app/views/media_vault/media/_archive_item.html.erb
@@ -11,7 +11,7 @@
     class="<%= archive_item_class_list %>"
     data-publishing-platform="<%= publishing_platform_shortname %>"
     data-controller="media-vault--archive"
-    data-archive-caption-collapse-mode-value="<%= caption_is_collapsable ? 'collapsed' : 'static' %>"
+    data-media-vault--archive-caption-collapse-mode-value="<%= caption_is_collapsable ? 'collapsed' : 'static' %>"
 >
   <div class="archive-item__inner">
     <% if include_author %>
@@ -58,7 +58,7 @@
                 <button
                     class="archive-item__body-caption-toggler"
                     data-media-vault--archive-target="captionToggler"
-                    data-action="archive#toggleCaption"
+                    data-action="media-vault--archive#toggleCaption"
                     data-collapse-label="Collapse caption ↑"
                     data-expand-label="Expand caption ↓"
                 >Expand caption ↓</button>


### PR DESCRIPTION
_This PR ladders off #461._

This PR fixes the issue with expand/collapse caption links not working. This was because when I nested the JS within the MediaVault namespace, some of the attributes that needed changing didn't get changed.

Closes #468