### PR TITLE
Send email to admins when an applicant applies

### DIFF
--- a/app/mailers/new_applicant_alert_mailer.rb
+++ b/app/mailers/new_applicant_alert_mailer.rb
@@ -1,0 +1,17 @@
+class NewApplicantAlertMailer < ApplicationMailer
+  def new_applicant_email
+    @applicant = params[:applicant]
+    # For aesthetic purposes
+    @site = @applicant.source_site == "media_vault" ? SiteDefinitions::MEDIA_VAULT : SiteDefinitions::FACT_CHECK_INSIGHTS
+
+    # Send an email to all admins
+    admins = User.with_role(:admin)
+    admin_emails = admins.map { |admin| admin.email }
+
+    mail({
+      from: email_address_with_name("no-reply@#{Figaro.env.MAIL_DOMAIN}", @site[:title]),
+      to: admin_emails,
+      subject: "New user application for #{@site[:title]}"
+    })
+  end
+end

--- a/app/views/new_applicant_alert_mailer/new_applicant_email.html.erb
+++ b/app/views/new_applicant_alert_mailer/new_applicant_email.html.erb
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>A new user has requested access to <%= @site[:title] %>.</p>
+    <hr>
+    <p>Name: <%= @applicant.name %></p>
+    <p>Affiliation: <%= @applicant.affiliation %></p>
+    <p>Primary Role: <%= @applicant.primary_role %></p>
+    <p>Country: <%= @applicant.country %></p>
+    <p>Email: <%= @applicant.email %></p>
+    <p>Time of Request: <%= @applicant.created_at %></p>
+    <p>Use Case: <%= @applicant.use_case %></p>
+
+    <hr>
+
+    <p><%= link_to "Click here to review application in the administration panel", admin_applicant_url(id: @applicant.id) %>, or visit this URL in your browser:</p>
+    <pre><%= admin_applicant_url(id: @applicant.id) %></pre>
+
+    <p><%= link_to "See all pending applications", admin_applicants_url %>, or visit this URL in your browser:</p>
+    <pre><%= admin_applicants_url %></pre>
+
+    <p>QED</p>
+  </body>
+</html>

--- a/test/mailers/new_applicant_alert_mailer_test.rb
+++ b/test/mailers/new_applicant_alert_mailer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NewApplicantAlertMailerTest < ActionMailer::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/mailers/previews/new_applicant_alert_mailer_preview.rb
+++ b/test/mailers/previews/new_applicant_alert_mailer_preview.rb
@@ -1,0 +1,12 @@
+# Preview all emails at http://localhost:3000/rails/mailers/new_applicant_alert_mailer
+class NewApplicantAlertMailerPreview < ActionMailer::Preview
+  def new_applicant_email
+    NewApplicantAlertMailer.with(
+      applicant: {
+        email: "applicant@example.com",
+        confirmation_token: "asdf1234",
+      },
+      site: SiteDefinitions::FACT_CHECK_INSIGHTS,
+    ).new_applicant_email
+  end
+end

--- a/test/models/applicant_test.rb
+++ b/test/models/applicant_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
+require "action_mailer/test_helper"
 
 class ApplicantTest < ActiveSupport::TestCase
+  include ActionMailer::TestHelper
+
   def setup
     @applicant = Applicant.new
   end
@@ -188,5 +191,15 @@ class ApplicantTest < ActiveSupport::TestCase
     confirmed_applicant.reload
 
     assert_equal admin, confirmed_applicant.reviewer
+  end
+
+  test "sends email to admins when confirmed" do
+    ActionMailer::Base.deliveries.clear # clear all emails
+
+    new_applicant = applicants(:new)
+
+    assert_emails 1 do
+      assert new_applicant.confirm
+    end
   end
 end


### PR DESCRIPTION
After an applicant confirms their email address send an email to all admins (maybe later we want to be able to designate a single contact) alerting them, and pointing them to the right pages.

To Test:
1. Make sure the app and sidekiq are running
2. Make sure you're logged out and apply
3. You'll get an email asking for confirmation to your email. Go ahead and answer it. Or, go into the console and call `.confirm` on the applicant
4. Check sidekiq and you should see the email printed out in the log (since our admins emails point to `example.com` you won't really receive the email itself.
5. Try this in Vault and Insights)

Closes #436