### PR TITLE
Add download link to individual media pages

### DIFF
--- a/app/assets/stylesheets/archive_items.scss
+++ b/app/assets/stylesheets/archive_items.scss
@@ -42,6 +42,7 @@ just to examine the template files unless/until we capture it better here.
 					<div class="archive-item__metadatum__label"></div>
 					<div class="archive-item__metadatum__value"></div>
 				</div>
+        <div class="archive-item__download__link"></div>
 				…
 			</div>
 		</div>
@@ -227,6 +228,10 @@ just to examine the template files unless/until we capture it better here.
 			align-self: flex-start;
 		}
 	}
+}
+
+div.archive-item__download__link {
+  font-weight: 400
 }
 
 a.archive-item__metadatum {

--- a/app/assets/stylesheets/archive_items.scss
+++ b/app/assets/stylesheets/archive_items.scss
@@ -231,7 +231,7 @@ just to examine the template files unless/until we capture it better here.
 }
 
 div.archive-item__download__link {
-  font-weight: 400
+  font-weight: 400;
 }
 
 a.archive-item__metadatum {

--- a/app/controllers/media_vault/archive_controller.rb
+++ b/app/controllers/media_vault/archive_controller.rb
@@ -90,7 +90,7 @@ class MediaVault::ArchiveController < MediaVaultController
   # Export entire archive of reviewed media to a JSON File
   sig { void }
   def export_archive_data
-    send_data ArchiveItem.generate_pruned_json,
+    send_data ArchiveItem.generate_json_for_export,
       type: "application/json",
       filename: "media_vault_archive.json"
   end

--- a/app/controllers/media_vault/authors_controller.rb
+++ b/app/controllers/media_vault/authors_controller.rb
@@ -50,7 +50,7 @@ class MediaVault::AuthorsController < MediaVaultController
     respond_to do |format|
       format.html do; end
       format.json do
-        send_data ArchiveItem.generate_pruned_json(@archive_items),
+        send_data ArchiveItem.generate_json_for_export(@archive_items),
           type: "application/json",
           filename: "#{@author.send(@platform[:author_name_method]).parameterize(separator: '_')}_#{typed_params.platform}_archive.json"
       end

--- a/app/controllers/media_vault/media_controller.rb
+++ b/app/controllers/media_vault/media_controller.rb
@@ -6,6 +6,7 @@ class MediaVault::MediaController < MediaVaultController
     @archive_item = ArchiveItem.find(params[:id])
   end
 
+  # Exports JSON-formatted metadata about a piece of media
   sig { void }
   def export_metadata
     archive_item = ArchiveItem.includes(:media_review, archivable_item: [:author]).find(params[:id])

--- a/app/controllers/media_vault/media_controller.rb
+++ b/app/controllers/media_vault/media_controller.rb
@@ -12,7 +12,7 @@ class MediaVault::MediaController < MediaVaultController
     archive_item = ArchiveItem.includes(:media_review, archivable_item: [:author]).find(params[:id])
 
     # Parse JSON string, extract first (and only) item from array, then convert back to a string
-    archive_item_export = JSON.parse(ArchiveItem.generate_json_for_export([archive_item])).first.to_json
+    archive_item_export = JSON.pretty_generate(JSON.parse(ArchiveItem.generate_json_for_export([archive_item])).first)
 
     send_data archive_item_export,
       type: "application/json",

--- a/app/controllers/media_vault/media_controller.rb
+++ b/app/controllers/media_vault/media_controller.rb
@@ -5,4 +5,16 @@ class MediaVault::MediaController < MediaVaultController
   def show
     @archive_item = ArchiveItem.find(params[:id])
   end
+
+  sig { void }
+  def export_metadata
+    archive_item = ArchiveItem.includes(:media_review, archivable_item: [:author]).find(params[:id])
+
+    # Parse JSON string, extract first (and only) item from array, then convert back to a string
+    archive_item_export = JSON.parse(ArchiveItem.generate_json_for_export([archive_item])).first.to_json
+
+    send_data archive_item_export,
+      type: "application/json",
+      filename: "media_metadata.json"
+  end
 end

--- a/app/models/archive_item.rb
+++ b/app/models/archive_item.rb
@@ -67,7 +67,7 @@ class ArchiveItem < ApplicationRecord
   # @params relation T.Array[ArchiveItem] a set of ArchiveItems to be exported
   # @return a stringified representation of ArchiveItems for export
   sig { params(relation: T.nilable(T::Array[ArchiveItem])).returns(String) }
-  def self.generate_pruned_json(relation = nil)
+  def self.generate_json_for_export(relation = nil)
     relation ||= ArchiveItem.includes(:media_review, archivable_item: [:author])
     relation.to_json(only: [:id, :created_at],
                      include: [ { media_review: { except: [:id, :created_at, :updated_at, :archive_item_id] } },

--- a/app/views/media_vault/media/_archive_item.html.erb
+++ b/app/views/media_vault/media/_archive_item.html.erb
@@ -65,7 +65,7 @@
             <% end %>
         </div>
     </div>
-    <div class="archive-item__metadata">
+    <div class="archive-item__metadata" style="justify-content: flex-start">
         <div class="icon-prefixed">
           <%= use_svg publishing_platform_shortname, svg_attrs: { class: "icon", aria: { hidden: true } } %>
           <div class="archive-item__metadatum">
@@ -88,6 +88,9 @@
             >
                 <%= archived_at %>
             </time>
+        <% end %>
+        <%= link_to media_vault_export_media_metadata_path(archive_item_self.archive_item.id) do %>
+          <div class="archive-item__download__link">Download media metadata</div>
         <% end %>
     </div>
   </div>

--- a/app/views/media_vault/media/_archive_item.html.erb
+++ b/app/views/media_vault/media/_archive_item.html.erb
@@ -65,33 +65,37 @@
             <% end %>
         </div>
     </div>
-    <div class="archive-item__metadata" style="justify-content: flex-start">
-        <div class="icon-prefixed">
-          <%= use_svg publishing_platform_shortname, svg_attrs: { class: "icon", aria: { hidden: true } } %>
-          <div class="archive-item__metadatum">
-              <div class="archive-item__metadatum__label">Published on <%= publishing_platform_display_name %></div>
-              <time
-                  class="archive-item__metadatum__value"
-                  datetime="<%= published_at.iso8601 %>"
-                  data-media-vault--archive-target="timestamp"
-              >
-                  <%= published_at %>
-              </time>
-          </div>
+    <div class="archive-item__metadata justify-between">
+        <div class="flex justify-start space-x-4">
+            <div class="icon-prefixed">
+              <%= use_svg publishing_platform_shortname, svg_attrs: { class: "icon", aria: { hidden: true } } %>
+              <div class="archive-item__metadatum">
+                  <div class="archive-item__metadatum__label">Published on <%= publishing_platform_display_name %></div>
+                  <time
+                      class="archive-item__metadatum__value"
+                      datetime="<%= published_at.iso8601 %>"
+                      data-media-vault--archive-target="timestamp"
+                  >
+                      <%= published_at %>
+                  </time>
+              </div>
+            </div>
+            <%= link_to media_vault_medium_path(archive_item_self.archive_item), class: "archive-item__metadatum" do %>
+                <div class="archive-item__metadatum__label">Archived</div>
+                <time
+                    class="archive-item__metadatum__value"
+                    datetime="<%= archived_at.iso8601 %>"
+                    data-media-vault--archive-target="timestamp"
+                >
+                    <%= archived_at %>
+                </time>
+            <% end %>
         </div>
-        <%= link_to media_vault_medium_path(archive_item_self.archive_item), class: "archive-item__metadatum" do %>
-            <div class="archive-item__metadatum__label">Archived</div>
-            <time
-                class="archive-item__metadatum__value"
-                datetime="<%= archived_at.iso8601 %>"
-                data-media-vault--archive-target="timestamp"
-            >
-                <%= archived_at %>
-            </time>
-        <% end %>
-        <%= link_to media_vault_export_media_metadata_path(archive_item_self.archive_item.id) do %>
-          <div class="archive-item__download__link">Download media metadata</div>
-        <% end %>
+        <div class="flex items-center">
+            <%= link_to media_vault_export_media_metadata_path(archive_item_self.archive_item.id) do %>
+              <div class="archive-item__download__link">Download media metadata</div>
+            <% end %>
+        </div>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
 
       get "authors/:platform/:id", to: "authors#show", as: "author"
       resources :media, only: [:show]
+      get "media/download_metadata/:id", to: "media#export_metadata", as: "export_media_metadata"
     end
   end
 

--- a/test/controllers/media_vault/media_controller_test.rb
+++ b/test/controllers/media_vault/media_controller_test.rb
@@ -21,12 +21,12 @@ class MediaVault::MediaControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_user_session_path
   end
 
-  test "can export media item metadata" do 
+  test "can export media item metadata" do
     user = users(:user)
     sign_in user
 
     archive_item = Sources::Tweet.create_from_url!("https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
-   
+
     get media_vault_export_media_metadata_path(archive_item.id)
     assert_response :success
     assert_equal "application/json", response.content_type

--- a/test/controllers/media_vault/media_controller_test.rb
+++ b/test/controllers/media_vault/media_controller_test.rb
@@ -1,7 +1,16 @@
 require "test_helper"
 
 class MediaVault::MediaControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
   include Devise::Test::IntegrationHelpers
+  include Minitest::Hooks
+
+  def around
+    AwsS3Downloader.stub(:download_file_in_s3_received_from_hypatia, S3_MOCK_STUB) do
+      super
+    end
+  end
+
 
   setup do
     host! Figaro.env.MEDIA_VAULT_HOST
@@ -10,6 +19,20 @@ class MediaVault::MediaControllerTest < ActionDispatch::IntegrationTest
   test "cannot view media if not logged in" do
     get media_vault_medium_path(id: "abc123")
     assert_redirected_to new_user_session_path
+  end
+
+  test "can export media item metadata" do 
+    user = users(:user)
+    sign_in user
+
+    archive_item = Sources::Tweet.create_from_url!("https://twitter.com/AmtrakNECAlerts/status/1397922363551870990")
+   
+    get media_vault_export_media_metadata_path(archive_item.id)
+    assert_response :success
+    assert_equal "application/json", response.content_type
+
+    json = JSON.parse response.body
+    assert json.has_key?("archivable_item")
   end
 
   # TODO: Make this test work by ensuring we have ArchiveItem fixtures


### PR DESCRIPTION
This PR adds a download link to individual media pages, allowing for the export of metadata for lone pieces of media (see below). 
![image](https://user-images.githubusercontent.com/9507998/213470193-7a74f2bb-8523-4492-90f2-84c44501d05a.png)

Closes #481 
### Testing instructions
- `rake`
- Log in to MediaVault, navigate to the dasbhoard, and try clicking a media item's download link