### PR TITLE
Move scrape callback ingestion to job

### DIFF
--- a/app/controllers/media_vault/archive_controller.rb
+++ b/app/controllers/media_vault/archive_controller.rb
@@ -128,7 +128,7 @@ class MediaVault::ArchiveController < MediaVaultController
       parsed_result = [parsed_result]
     end
 
-    scrape.fulfill(parsed_result)
+    ScrapeCallbackJob.perform_later(scrape, parsed_result)
 
     render plain: "OK", status: 200
   end

--- a/app/controllers/media_vault/ingest_controller.rb
+++ b/app/controllers/media_vault/ingest_controller.rb
@@ -42,14 +42,22 @@ class MediaVault::IngestController < MediaVaultController
     end
 
     class JSONParseException < StandardError
+      def initialize(json)
+        @json = json
+      end
+
       def message
-        JSONParseError.message
+        "JSON Parser exception. Json: #{@json}"
       end
     end
 
     class JSONValidationException < StandardError
+      def initialize(json)
+        @json = json
+      end
+
       def message
-        JSONValidationError.message
+        "JSON Validation exception. Json: #{@json}"
       end
     end
 

--- a/app/jobs/scrape_callback_job.rb
+++ b/app/jobs/scrape_callback_job.rb
@@ -1,0 +1,9 @@
+class ScrapeCallbackJob < ApplicationJob
+  queue_as :default
+
+  # Type is :media_review or :claim_review
+  def perform(scrape, parsed_result)
+    scrape
+    scrape.fulfill(parsed_result)
+  end
+end

--- a/app/models/scrape.rb
+++ b/app/models/scrape.rb
@@ -31,6 +31,13 @@ class Scrape < ApplicationRecord
                         response.first.key?("status") &&
                         response.first["status"] == "removed"
 
+    # If it's removed we just bail now, clears up the logic for a bit of repetition
+    if removed
+      self.update!({ fulfilled: true, removed: true, archive_item: nil })
+      send_notification && return
+    end
+
+    # Process everything correctly now that we know it's not removed
     media_review_item = MediaReview.find_by(original_media_link: self.url,
                                             archive_item_id: nil,
                                             taken_down: nil)

--- a/test/jobs/ingest_job_test.rb
+++ b/test/jobs/ingest_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class IngestJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This moves the scrape fulfillment to a job so that we're not blocking the main thread and can finish up the request quickly before managing transcoding and such.

Also now properly handles removed posts when returned from Hypatia without erroring out.

Closes #529